### PR TITLE
Unc virtual coll

### DIFF
--- a/lib/data/unc/marc_specs.yml
+++ b/lib/data/unc/marc_specs.yml
@@ -2,3 +2,5 @@ id:
   - 907a
 date_cataloged:
   - 909a
+virtual_collection:
+  - 919t

--- a/lib/data/unc/traject_config.rb
+++ b/lib/data/unc/traject_config.rb
@@ -26,6 +26,7 @@ end
 ######\
 to_field 'institution', literal('unc')
 
+to_field 'virtual_collection', extract_marc(settings['specs'][:virtual_collection], :separator => nil)
 ################################################
 # oclc_number, sersol_number, rollup_id
 # 001, 003, 035

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.0.27'.freeze
+  VERSION = '0.0.28'.freeze
 end

--- a/spec/data/unc/b1082803.xml
+++ b/spec/data/unc/b1082803.xml
@@ -62,6 +62,9 @@
       <datafield ind1=' ' ind2=' ' tag='907'>
         <subfield code='a'>b1082803</subfield>
       </datafield>
+      <datafield ind1=' ' ind2=' ' tag='919'>
+        <subfield code='a'>DWSGPO</subfield>
+      </datafield>
       <datafield ind1='9' ind2='1' tag='999'>
         <subfield code='i'>i1147335</subfield>
         <subfield code='l'>ddda</subfield>

--- a/spec/data/unc/b1246383.xml
+++ b/spec/data/unc/b1246383.xml
@@ -192,6 +192,9 @@
       <datafield ind1=' ' ind2=' ' tag='907'>
         <subfield code='a'>b1246383</subfield>
       </datafield>
+      <datafield ind1=' ' ind2=' ' tag='919'>
+        <subfield code='t'>testcoll</subfield>
+      </datafield>
       <datafield ind1='9' ind2='1' tag='999'>
         <subfield code='i'>i1430977</subfield>
         <subfield code='l'>trln</subfield>

--- a/spec/data/unc/b1319986.xml
+++ b/spec/data/unc/b1319986.xml
@@ -58,6 +58,10 @@
       <datafield ind1=' ' ind2=' ' tag='907'>
         <subfield code='a'>b1319986</subfield>
       </datafield>
+      <datafield ind1=' ' ind2=' ' tag='919'>
+        <subfield code='t'>testcoll</subfield>
+        <subfield code='t'>anothercoll</subfield>
+      </datafield>
       <datafield ind1='9' ind2='1' tag='999'>
         <subfield code='i'>i1688265</subfield>
         <subfield code='l'>mmdb</subfield>

--- a/spec/unc_spec.rb
+++ b/spec/unc_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe MarcToArgot do
+  include Util::TrajectRunTest
+  let(:b1082803argot) { run_traject_json('unc', 'b1082803') }
+  let(:b1246383argot) { run_traject_json('unc', 'b1246383') }
+  let(:b1319986argot) { run_traject_json('unc', 'b1319986') }
+  
+  it '(UNC) does not set virtual collection from 919$a' do
+    expect(b1082803argot['virtual_collection']).to(
+      eq(nil)
+    )
+  end
+
+  it '(UNC) sets virtual collection from 919$t' do
+    expect(b1246383argot['virtual_collection']).to(
+      eq(['testcoll'])
+    )
+  end
+
+  it '(UNC) sets virtual collection from repeated 919$t' do
+    expect(b1319986argot['virtual_collection']).to(
+      eq(['testcoll', 'anothercoll'])
+    )
+  end
+end


### PR DESCRIPTION
Adds extraction of virtual_collection field for UNC.

I didn't put anything in the shared config for this field because a) it works without it; and b) there's no shared logic that would do anything reasonably useful.