### PR TITLE
Remove copyright_year, copyright_data specs

### DIFF
--- a/lib/data/argot/marc_specs.yml
+++ b/lib/data/argot/marc_specs.yml
@@ -28,8 +28,6 @@ issn:
     - 785xz
   series:
     - 490x
-copyright_data:
-  - 264c
 publisher:
   - 260bf
   - 264b

--- a/lib/data/argot/traject_config.rb
+++ b/lib/data/argot/traject_config.rb
@@ -75,17 +75,6 @@ unless settings["override"].include?("publication_year")
   to_field "publication_year", marc_publication_date
 end
 
-unless settings["override"].include?("copyright_year")
-  to_field "copyright_year" do |record, acc|
-    Traject::MarcExtractor.cached("264c").each_matching_line(record) do |field, spec, extractor|
-       if field.indicator2 == '4'
-            str = extractor.collect_subfields(field,spec).first
-            acc << str.gsub!(/[^\d]/,'').to_i if str
-       end
-    end
-  end
-end
-
 unless settings['override'].include?('date_cataloged')
   to_field 'date_cataloged' do |rec, acc|
     cataloged = Traject::MarcExtractor.cached(settings['specs'][:date_cataloged]).extract(rec).first

--- a/lib/data/ncsu/marc_specs.yml
+++ b/lib/data/ncsu/marc_specs.yml
@@ -31,8 +31,6 @@ issn:
 
 date_cataloged:
   - 909a
-copyright_data:
-  - 264c
 publisher_number:
   - 028ab
 publisher_etc:

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.0.30'.freeze
+  VERSION = '0.0.31'.freeze
 end


### PR DESCRIPTION
Side effect is that symbols and non-digit characters are no longer stripped from =264 \4$c field values.