### PR TITLE
Td 553 implement field note serial dates

### DIFF
--- a/lib/data/argot/traject_config.rb
+++ b/lib/data/argot/traject_config.rb
@@ -262,6 +262,10 @@ unless settings["override"].include?("note_with")
   to_field "note_with", extract_marc(settings["specs"][:note_with])
 end
 
+unless settings["override"].include?("note_serial_dates")
+  to_field "note_serial_dates", note_serial_dates
+end
+
 ################################################
 # URLs
 ######

--- a/lib/marc_to_argot/macros/shared/notes.rb
+++ b/lib/marc_to_argot/macros/shared/notes.rb
@@ -427,6 +427,20 @@ module MarcToArgot
         end
       end
 
+      ###############################################
+      #Note serial dates
+      #########
+      def note_serial_dates
+        lambda do |rec, acc|
+          Traject::MarcExtractor.cached("362az").each_matching_line(rec) do |field, spec, extractor|
+            next unless subfield_5_absent_or_present_with_local_code?(field)
+            a = field.subfields.select { |sf| sf.code == 'a' }.map { |sf| sf.value }
+            z = field.subfields.select { |sf| sf.code == 'z' }.map { |sf| "(#{sf.value.gsub(/Cf./i, "Data from:")})" }
+            acc << [a,z].compact.join(' ').rstrip
+          end
+        end
+      end
+
       ################################################
       # Note System Details
       ######

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.0.59'.freeze
+  VERSION = '0.0.60'.freeze
 end

--- a/spec/macros/shared/notes_spec.rb
+++ b/spec/macros/shared/notes_spec.rb
@@ -352,7 +352,7 @@ describe MarcToArgot::Macros::Shared::Notes do
     expect(result).to include('Scale 1:33,000,000 ; Mercator projection (E 15°--E 60°/N 45°--N 15°).')
   end
 
-  xit '(MTA) sets note_serial_dates from 362' do
+  it '(MTA) sets note_serial_dates from 362' do
     result = note_serial_dates['note_serial_dates']
     expect(result).to eq(
                         ['Began with v. 1 in 1846; ceased in Mar. 1934. (Data from: Union list of serials.)',


### PR DESCRIPTION
Let me know if there is more efficient way to define the note_serial_dates method.