### PR TITLE
move items with type=GAME to special narrow location

### DIFF
--- a/lib/marc_to_argot/macros/ncsu/items.rb
+++ b/lib/marc_to_argot/macros/ncsu/items.rb
@@ -94,7 +94,7 @@ module MarcToArgot
             item['loc_n'] = item['loc_current']
           end
           # now some remappings based on item type
-          item['loc_b'] = 'GAME' if item['type'] == 'GAME-4HR'
+          item['loc_n'] = 'GAME' if item['type'] == 'GAME-4HR'
         end
 
         def library_use_only?(item)

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.1.4'.freeze
+  VERSION = '0.1.5'.freeze
 end


### PR DESCRIPTION
Bugfix: maps items with type = game to *narrow* location for games instead of broad location. (removes `ncsu.facet.GAME` in hierarchy)