### PR TITLE
fix empty oclc numbers/bad rollup ids (ncsu)

### DIFF
--- a/lib/marc_to_argot/macros/ncsu_macros.rb
+++ b/lib/marc_to_argot/macros/ncsu_macros.rb
@@ -41,6 +41,8 @@ module MarcToArgot
             oclc = control_number_extor.extract(rec).first
             acc << oclc.gsub(/^\D*/, '') unless oclc.nil?
           end
+          acc.compact!
+          acc.reject!(&:empty?)
           acc.uniq!
           acc.map! { |x| "OCLC#{x}" }
         end

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.1.6'.freeze
+  VERSION = '0.1.7'.freeze
 end

--- a/lib/traject/argot_semantics.rb
+++ b/lib/traject/argot_semantics.rb
@@ -29,8 +29,9 @@ module Traject::Macros
             st[key] = oclc_num unless oclc_num.empty?
           end
         end
+        val = st['value']
 
-        acc << st unless st.empty?
+        acc << st unless val.nil? || val.empty?
       end
     end
 

--- a/spec/data/ncsu/oclc003-empty-001.xml
+++ b/spec/data/ncsu/oclc003-empty-001.xml
@@ -1,0 +1,114 @@
+<collection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/MARC21/slim" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
+<record>
+  <leader>01443cgm a2200385Ia 4500</leader>
+  <controlfield tag="001"/>
+  <controlfield tag="003">OCoLC</controlfield>
+  <controlfield tag="007">vd*cvaiuz</controlfield>
+  <controlfield tag="008">      s1996    cou072            vleng d</controlfield>
+  <datafield tag="013" ind1=" " ind2=" ">
+    <subfield code="a">a</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(Sirsi) a3085133</subfield>
+  </datafield>
+  <datafield tag="043" ind1=" " ind2=" ">
+    <subfield code="a">n-us---</subfield>
+  </datafield>
+  <datafield tag="049" ind1=" " ind2=" ">
+    <subfield code="a">NRCC</subfield>
+    <subfield code="x">tmc</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">NRC</subfield>
+    <subfield code="b">eng</subfield>
+    <subfield code="c">NRC</subfield>
+  </datafield>
+  <datafield tag="090" ind1=" " ind2=" ">
+    <subfield code="a">SD565</subfield>
+    <subfield code="b">.F576 1996b</subfield>
+  </datafield>
+  <datafield tag="245" ind1="0" ind2="0">
+    <subfield code="a">Forest wars</subfield>
+    <subfield code="h">[videorecording] /</subfield>
+    <subfield code="c">written by Nicolas Brown, Patrick Prentice.</subfield>
+  </datafield>
+  <datafield tag="260" ind1=" " ind2=" ">
+    <subfield code="a">[Aspen, CO]? :</subfield>
+    <subfield code="b">Produced for the Earth Vision Institute by Summit Films, Inc.,</subfield>
+    <subfield code="c">c1996.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">1 DVD-ROM (72 min.) :</subfield>
+    <subfield code="b">sd., col ;</subfield>
+    <subfield code="c">4 3/4 in.</subfield>
+  </datafield>
+  <datafield tag="508" ind1=" " ind2=" ">
+    <subfield code="a">Produced by Roger C. Brown ; directed and edited by Nicolas Brown.</subfield>
+  </datafield>
+  <datafield tag="511" ind1="0" ind2=" ">
+    <subfield code="a">Presenter, Lee Horsley.</subfield>
+  </datafield>
+  <datafield tag="520" ind1=" " ind2=" ">
+    <subfield code="a">Documents an American dilemma: Can we have our wood products and our forests too?  Presents both sides of the legal and political log jam over forests.</subfield>
+  </datafield>
+  <datafield tag="538" ind1=" " ind2=" ">
+    <subfield code="a">DVD-ROM</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Forest management</subfield>
+    <subfield code="z">United States.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Conservation of natural resources</subfield>
+    <subfield code="z">United States.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Sustainable forestry</subfield>
+    <subfield code="z">United States.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Forest policy</subfield>
+    <subfield code="z">United States.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Brown, Nicolas Roether.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Prentice, Patrick.</subfield>
+  </datafield>
+  <datafield tag="710" ind1="2" ind2=" ">
+    <subfield code="a">Earth Vision Institute.</subfield>
+  </datafield>
+  <datafield tag="948" ind1=" " ind2=" ">
+    <subfield code="a">12/12/1996</subfield>
+    <subfield code="b">03/31/1997</subfield>
+  </datafield>
+  <datafield tag="919" ind1=" " ind2=" ">
+    <subfield code="a">AIM-9971</subfield>
+  </datafield>
+  <datafield tag="909" ind1=" " ind2=" ">
+    <subfield code="a">20140623</subfield>
+  </datafield>
+  <datafield tag="596" ind1=" " ind2=" ">
+    <subfield code="a">5</subfield>
+  </datafield>
+  <datafield tag="918" ind1=" " ind2=" ">
+    <subfield code="a">3085133</subfield>
+  </datafield>
+  <datafield tag="999" ind1=" " ind2=" ">
+    <subfield code="a">SD565 .F576 1996B</subfield>
+    <subfield code="w">LC</subfield>
+    <subfield code="c">1</subfield>
+    <subfield code="i">S02967139.</subfield>
+    <subfield code="d">8/7/2014</subfield>
+    <subfield code="e">6/23/2014</subfield>
+    <subfield code="l">MEDIA</subfield>
+    <subfield code="m">NRL</subfield>
+    <subfield code="r">Y</subfield>
+    <subfield code="s">Y</subfield>
+    <subfield code="t">DVD-ROM</subfield>
+    <subfield code="u">6/23/2014</subfield>
+  </datafield>
+</record>
+</collection>
+

--- a/spec/ncsu/ncsu_oclc_spec.rb
+++ b/spec/ncsu/ncsu_oclc_spec.rb
@@ -1,0 +1,12 @@
+describe MarcToArgot do
+  include Util::TrajectRunTest
+  let(:empty_001) { run_traject_json('ncsu', 'oclc003-empty-001') }
+
+  it 'fails to set an OCLC number when 001 is blank and 003=OCoLC' do
+    expect(empty_001['oclc_number']).to be_nil
+  end
+
+  it 'fails to generate a rollup id when oclc number is not present' do
+    expect(empty_001['rollup_id']).to be_nil
+  end
+end


### PR DESCRIPTION
NCSU records with empty 001 and 003=OCoLC would lead to (blank)-ish OCLC numbers and `rollup_id` = "OCLC" (TD-639)