### PR TITLE
Add logging adapter.  

### DIFF
--- a/lib/data/argot/traject_config.rb
+++ b/lib/data/argot/traject_config.rb
@@ -1,10 +1,30 @@
+## Traject configurations start by loading this file, and then they load 
+# institution/configuration specific files.  In order of execution, this means
+# that any field that is *not* overridden in an institution/configuration
+# specific file happens *after* any field that is mapped in this file.
+
+# The loader 'includes' shared macros in this file, and includes
+# institution-specific macros (if any) for the sub-configurations.  
+# What this means is that any macros (or methods) used in this file
+# will be the 'shared' versions, which may not be what you want.
+
+# Set up the main logger, used in macros and configuration files.
+# this version uses the `logging` gem with a custom adapter, allowing
+# us to set a mapped diagnostic context which can contain information about
+# the record being processed
+self.logger = Yell.new do |l|
+  l.adapter :logging_adapter, 
+    level: settings.fetch(:log_level, :warn), 
+    appender: settings.fetch(:appender, :stderr)
+end
+
 ################################################
 # IDs and Standard Numbers
 ######
 
-unless settings["override"].include?("id")
-  to_field "id", oclcnum("035a:035z")
-end
+#unless settings["override"].include?("id")
+#  to_field "id", record_id
+#end
 
 unless settings["override"].include?("record_data_source")
   to_field "record_data_source" do |rec, acc|
@@ -485,10 +505,3 @@ unless settings['override'].include?('institution')
     acc.concat(inst)
   end
 end
-
-# Other fields in endeca model that we're unsure how to map to
-# source_of_acquisition
-# related_collections
-# biographical_sketch
-# most_recent
-# holdings_note

--- a/lib/data/duke/overrides.yml
+++ b/lib/data/duke/overrides.yml
@@ -5,3 +5,4 @@
 - institution
 - items
 - holdings
+- names

--- a/lib/data/duke/traject_config.rb
+++ b/lib/data/duke/traject_config.rb
@@ -3,6 +3,7 @@
 ######
 to_field 'id', extract_marc(settings['specs'][:id], first: true) do |rec, acc|
   acc.collect! { |s| s.match(/DUKE.*/) ? s.to_s : "DUKE#{s}" }
+  Logging.mdc['record_id'] = acc.first
 end
 
 ################################################
@@ -34,6 +35,11 @@ end
 # Institutiuon
 ######
 to_field 'institution', literal('duke')
+
+##################
+# Names
+#########
+to_field 'names', names
 
 ################################################
 # Items
@@ -323,4 +329,8 @@ to_field 'holdings' do |rec, acc, context|
 
     acc << holding.to_json if holding.any?
   end
+end
+
+each_record do |rec, ctx|
+  Logging.mdc.clear
 end

--- a/lib/data/nccu/overrides.yml
+++ b/lib/data/nccu/overrides.yml
@@ -5,3 +5,4 @@
 - institution
 - items
 - access_type
+- names

--- a/lib/data/nccu/traject_config.rb
+++ b/lib/data/nccu/traject_config.rb
@@ -1,5 +1,6 @@
 to_field 'id', extract_marc(settings['specs'][:id], first: true) do |_rec, acc|
  acc.collect! { |s| "NCCU#{s}" }
+ Logging.mdc['record_id'] = acc.first
 end
 
 ################################################
@@ -14,3 +15,11 @@ to_field 'institution', literal('nccu')
 to_field 'items', extract_items
 
 to_field 'rollup_id', rollup_id
+
+to_field 'names', names
+
+
+
+each_record do |rec, ctx|
+  Logging.mdc.clear
+end

--- a/lib/data/ncsu/overrides.yml
+++ b/lib/data/ncsu/overrides.yml
@@ -7,3 +7,4 @@
 - access_type
 - physical_media
 - resource_type
+- names

--- a/lib/data/unc/overrides.yml
+++ b/lib/data/unc/overrides.yml
@@ -11,3 +11,4 @@
 - rollup_id
 - sersol_number
 - url
+- names

--- a/lib/data/unc/traject_config.rb
+++ b/lib/data/unc/traject_config.rb
@@ -7,6 +7,7 @@ end
 ######
 to_field 'id', extract_marc(settings['specs'][:id], :first => true) do |rec, acc|
   acc.collect! {|s| "UNC#{s}"}
+  Logging.mdc['record_id'] = acc.first
 end
 
 ################################################
@@ -41,6 +42,11 @@ to_field 'resource_type', resource_type
 ######
 to_field 'virtual_collection', extract_marc(settings['specs'][:virtual_collection], :separator => nil)
 
+################################################
+# Names
+###
+
+to_field 'names', names
 
 def process_donor_marc(rec)
   donors = []
@@ -321,4 +327,5 @@ end
 
 each_record do |rec, cxt|
   holdings(rec, cxt)
+  Logging.mdc.clear
 end

--- a/lib/marc_to_argot.rb
+++ b/lib/marc_to_argot.rb
@@ -1,3 +1,7 @@
+# Logging
+require 'yell'
+require 'yell/logging_adapter'
+
 # Traject
 require 'traject'
 require 'traject/macros/marc21_semantics'

--- a/lib/marc_to_argot/command_line.rb
+++ b/lib/marc_to_argot/command_line.rb
@@ -1,4 +1,5 @@
 require 'marc_to_argot'
+require 'yell/logging_adapter'
 require 'logger'
 
 module MarcToArgot
@@ -11,8 +12,6 @@ module MarcToArgot
     def __version
       puts "marc-to-argot version #{MarcToArgot::VERSION}, installed #{File.mtime(__FILE__)}"
     end
-
-
 
     ###############
     # Flatten

--- a/lib/marc_to_argot/macros/ncsu_macros.rb
+++ b/lib/marc_to_argot/macros/ncsu_macros.rb
@@ -55,8 +55,14 @@ module MarcToArgot
         end
       end
 
+      def open_access!(urls, items)
+        if items.any? { |i| i['item_cat_2'] == 'OPENACCESS' }
+          urls.each{ |u| u['open'] = true if u['type'] == 'fulltext' }
+        end
+      end
+
       def is_available?(items)
-        items.any? { |i| i['status'] =~ /^avail/i || i['loc_b'] == 'ONLINE' }
+        items.any? { |i| i.fetch('status', '').match?(/^avail/i) || i['loc_b'] == 'ONLINE' }
       end
 
       def online_access?(_rec, libraries = [])

--- a/lib/marc_to_argot/macros/shared/names.rb
+++ b/lib/marc_to_argot/macros/shared/names.rb
@@ -7,16 +7,17 @@ module MarcToArgot
         ######
 
         def names
-          lambda do |rec, acc|
+          lambda do |rec, acc, ctx|
             Traject::MarcExtractor.cached('100:110:111:700:710:711:720', :alternate_script => false)
                                   .each_matching_line(rec) do |field, spec, extractor|
 
               next unless passes_names_constraint?(field)
               next unless subfield_5_absent_or_present_with_local_code?(field)
-
+              Logging.mdc['field'] = field.tag
               names = assemble_names_hash(field)
 
               acc << names unless names.empty?
+              Logging.mdc.delete('field')
             end
           end
         end
@@ -32,6 +33,7 @@ module MarcToArgot
         end
 
         def names_name(field)
+          
           name = ''
           case field.tag
           when /(100|700)/

--- a/lib/marc_to_argot/macros/shared/title.rb
+++ b/lib/marc_to_argot/macros/shared/title.rb
@@ -2,6 +2,18 @@ module MarcToArgot
   module Macros
     module Shared
       module Title
+
+        # populates the 'short_title' of a Traject output_hash
+        # if the title is
+        def short_titles!(output_hash, max_length = 4)
+          main_title = output_hash.fetch('title_main', '')
+          return if main_title.empty?
+          words = main_title.first[:value].split(/\s+/)
+          if words.length <= max_length
+            output_hash["short_title"] = words.join(' ')
+          end
+        end
+        
         ################################################
         # Title Main
         ######

--- a/lib/marc_to_argot/macros/shared_macros.rb
+++ b/lib/marc_to_argot/macros/shared_macros.rb
@@ -40,11 +40,15 @@ module MarcToArgot
       include Urls
       include Vernacular
       include WorkEntry
-      include CallNumbers
+      include CallNumbers      
 
       # values to look for in the 856 that indicate
       # a record has online access.
       ELOC_IND2 = Set.new(%w[0 1])
+
+      def record_id
+        oclcnum("035a:035z")
+      end
 
       # tests whether the record has an 856[ind2] that matches
       # any of the values in ELOC_IND2

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.1.23'.freeze
+  VERSION = '0.1.24'.freeze
 end

--- a/lib/yell/logging_adapter.rb
+++ b/lib/yell/logging_adapter.rb
@@ -1,0 +1,85 @@
+require 'yell'
+require 'logging'
+
+# Adapter that allows Yell to use logging
+# gem.  This adapter always creates a logger
+# that outputs to STDERR
+#
+# https://github.com/TwP/logging
+#
+# A primary benefit of using this adapter is that it gives
+# access to a mapped diagnostic context (MDC), which is a shared
+# hash that can store pieces of info that are output in log mesages.
+# To set a value in the MDC:
+# `Logging.mdc['record_id'] = ids.first`
+# To unset it:
+# `Logging.mdc.remove('record_id')`
+# To clear the MDC:
+#  `Logging.mdc.clear``
+#
+# The default pattern for output messages is
+# `"[%d] %-5l <%X{record_id}#[%X{field}]>: %m \n")`
+# (timestamp, level, record_id + '#' + field from MDC`, message)
+# X{foo} outputs values from the MDC
+class LoggingAdapter < Yell::Adapters::Base
+  include Yell::Helpers::Base
+  include Yell::Helpers::Formatter
+
+  attr_reader :logger, :appender
+
+  DEFAULT_PATTERN = "[%d] %-5l <%X{record_id}#[%X{field}]>: %m \n".freeze
+
+  DEFAULT_DATE_PATTERN = '%Y-%m-%dT%H:M:%s.%s'.freeze
+
+  setup do |options|
+    @pattern = options.fetch(:pattern, DEFAULT_PATTERN)
+    @date_pattern = options.fetch(:date_pattern, DEFAULT_DATE_PATTERN)
+    appender_name = options.fetch(:appender, :stderr)
+    layout = Logging.layouts.pattern(
+      pattern: @pattern,
+      date_pattern: @date_pattern
+    )
+    @appender = case appender_name
+                when :stderr
+                  Logging.appenders.stderr('stderr', layout: layout)
+                when :stdout
+                  Logging.appenders.stdout('stdout', layout: layout)
+                when :string_io
+                  Logging.appenders.string_io.new('string_io')
+                else
+                  Logging.appenders.stderr('stderr', layout: layout)
+                end
+
+    if @logger.nil?
+      @logger = Logging::Logger[options.fetch('logger_name', 'mta')]
+      @logger.add_appenders(@appender)
+      @logger.level = options.fetch(:level, :warn)
+    end
+  end
+
+  write do |event|
+    lvl = event.level
+    case lvl
+    when 0 # lvl.at?(:debug)
+      @logger.debug(event.messages.join(' '))
+    when 1 # lvl.at?(:info)
+      @logger.info(event.messages.join(' '))
+    when 2 # lvl.at?(:warn)
+      @logger.warn(event.messages.join(' '))
+    when 3 # lvl.at?(:error)
+      @logger.warn(event.messages.join(' '))
+    when 4 # lvl.at?(:fatal)
+      @logger.warn(event.messages.join(' '))
+    else
+      @logger.warn("Unhandled level #{event.level.inspect} : #{event.messages}")
+    end
+  end
+
+  private
+
+  def map_event(yell_event)
+    Logging::LogEvent.new(@logger, yell_event.level, yell_event.messages, false)
+  end
+end
+
+Yell::Adapters.register :logging_adapter, LoggingAdapter

--- a/marc_to_argot.gemspec
+++ b/marc_to_argot.gemspec
@@ -49,6 +49,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency 'yajl-ruby', ['>=1.3.1']
   end
 
+  s.add_runtime_dependency 'logging', '~> 2.2.2'
   s.add_runtime_dependency 'library_stdnums'
   s.add_runtime_dependency 'lcsort', '~> 0.9.0'
   s.add_runtime_dependency 'thor', ['~> 0.19.4']

--- a/spec/yell/logging_adapter_spec.rb
+++ b/spec/yell/logging_adapter_spec.rb
@@ -1,0 +1,15 @@
+describe LoggingAdapter do
+  it 'initializes normally' do
+    Yell.new do |l|
+      l.adapter :logging_adapter
+    end
+    Yell::Logger.new.info "Hi there"
+  end
+  
+  it 'initializes with :stderr appender' do
+    Yell.new do |l|
+      l.adapter :logging_adapter, appender: :stderr
+    end
+    Yell::Logger.new.info "Hi there"
+  end
+end


### PR DESCRIPTION
Add TwP/logging adapter (https://github.com/TwP/logging/)
Set default logging to use that adapter (shared traject config)
Add record ID to logger's MDC (shows which record we were processing when warnings are emitted) for each institutional configuration.
Add field name to MDC when logging warnings of bad relator codes in 'names' handling
Override names handling for all configurations (so MDC data is available)
Clear MDC at end of each institutional configuration.

see `lib/yell/logging_adapter.rb` for more info

Detect open access URLs for NCSU
