### PR TITLE
unc items now gets item_id instead of id

### DIFF
--- a/lib/data/unc/traject_config.rb
+++ b/lib/data/unc/traject_config.rb
@@ -277,7 +277,7 @@ to_field 'items' do |rec, acc, ctx|
         when 'd'
           item['due_date'] = subfield.value
         when 'i'
-          item['id'] = subfield.value
+          item['item_id'] = subfield.value
         when 'l'
           item['loc_b'] = subfield.value
           item['loc_n'] = subfield.value

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.1.29'.freeze
+  VERSION = '0.1.30'.freeze
 end

--- a/spec/unc_items_spec.rb
+++ b/spec/unc_items_spec.rb
@@ -6,7 +6,7 @@ describe MarcToArgot do
 
   it '(UNC) sets item id (single item record)' do
     expect(b1082803argot['items'][0]).to(
-      include("\"id\":\"i1147335\"")
+      include("\"item_id\":\"i1147335\"")
     )
   end
 


### PR DESCRIPTION
Draft release: https://github.com/trln/marc-to-argot/releases/edit/untagged-e35d3d0bdcab567f167c