### PR TITLE
Td 768 publication year not populated

### DIFF
--- a/lib/data/argot/traject_config.rb
+++ b/lib/data/argot/traject_config.rb
@@ -91,7 +91,7 @@ end
 ######
 
 unless settings["override"].include?("publication_year")
-  to_field "publication_year", marc_publication_date
+  to_field "publication_year", publication_year
 end
 
 unless settings['override'].include?('date_cataloged')

--- a/lib/ext/marc/record.rb
+++ b/lib/ext/marc/record.rb
@@ -13,5 +13,20 @@ module MARC
       end
     end
 
+    # returns 008/06 as string
+    def date_type
+      self['008'].value[6] if self['008']
+    end
+
+    # returns 008/7-10 as string
+    def date1
+      self['008'].value[7..10] if self['008']
+    end
+
+    # returns 008/7-10 as string
+    def date2
+      self['008'].value[11..14] if self['008']
+    end
+
   end
 end

--- a/lib/marc_to_argot/macros/shared/helpers.rb
+++ b/lib/marc_to_argot/macros/shared/helpers.rb
@@ -7,6 +7,14 @@ module MarcToArgot
         # general helpers
         ################################################################
 
+        # tests whether at least one occurrence of field exists in record
+        # @param record [MARC::Record] the record to check
+        # @param field_tag [String] the tag of the field to check for
+        def field_present?(record, field_tag)
+          tags = record.tags
+          tags.include?(field_tag)
+        end
+        
         # tests whether a field's subfields with a particular code
         # contain any instance of a substring
         # @param field [MARC::DataField] the field to check for a subfield substring

--- a/lib/marc_to_argot/macros/shared/publication_year.rb
+++ b/lib/marc_to_argot/macros/shared/publication_year.rb
@@ -1,0 +1,211 @@
+module MarcToArgot
+  module Macros
+    module Shared
+      module PublicationYear
+
+        # Gets called from traject_config to populate the publication_year field
+        #  min_year: earliest date we consider to be a usable publication date
+        #    Defaults to 500.
+        #  max_year: latest date we consider to be a usable publication date
+        #    Defaults to current year, plus 6 (due to ridiculous publisher shenanigans)
+        #  range_tolerance: Maximum range we think is informative enough to set a
+        #    publication_year from.
+        #    Default so 500, which basically just throws out dates where we only know
+        #      which millennium: 1uuu, 2uuu
+        def publication_year(options = {})
+          min_year            = options[:min_year] || 500
+          max_year            = options[:max_year] || (Time.new.year + 6)
+          range_tolerance     = options[:range_tolerance] || 500
+          
+          lambda do |rec, acc|
+            date = set_year_from_008(rec, min_year, max_year, range_tolerance) if field_present?(rec, '008')
+            date = set_year_from_varfield(rec, min_year, max_year, range_tolerance) if date == nil
+            acc << date if date
+          end
+        end
+
+        # retrieves date from 008 if that field exists and data in it is usable
+        def set_year_from_008(rec, min, max, range_tolerance)
+          ff_date_type = rec.date_type
+          ff_date1 = get_date(rec.date1, min, max, 'fixed_field', range_tolerance)
+          ff_date2 = get_date(rec.date2, min, max, 'fixed_field', range_tolerance)
+
+          case ff_date_type
+          when 'b'
+            year_found = nil
+          when 'c'
+            year_found = ff_date2
+          when 'd'
+            year_found = date2_accounting_for_date1_in_range(ff_date1, rec.date2, min, max)
+          when 'e'
+            year_found = ff_date1
+          when 'i'
+            year_found = ff_date1
+          when 'k'
+            year_found = ff_date1
+          when 'm'
+            year_found = choose_ff_date(ff_date2, ff_date1, false)
+          when 'n'
+            year_found = midpoint_or_usable(ff_date1, ff_date2)
+          when 'p'
+            year_found = choose_ff_date(ff_date2, ff_date1, false)
+          when 'q'
+            year_found = midpoint_or_usable(ff_date1, ff_date2)
+          when 'r'
+            year_found = choose_ff_date(ff_date2, ff_date1, false)
+          when 's'
+            year_found = ff_date1
+          when 't'
+            year_found = ff_date1
+          when 'u'
+            year_found = choose_ff_date(ff_date2, ff_date1, true)
+          end
+          return year_found
+        end
+
+        # Retrieves date from the 260 or 264 used as main_imprint if we can't get a usable date
+        #  from 008
+        def set_year_from_varfield(rec, min, max, range_tolerance)
+          imprint_fields = []
+          Traject::MarcExtractor.cached("260:264").each_matching_line(rec) do |field, spec, extractor|
+            imprint_fields << field
+          end
+
+          # Selects which 260/264 field to use with the same logic as we set the imprint_main field
+          # THIS IS FROM THE IMPRINT MACRO
+          main_imprint = select_main_imprint(imprint_fields) unless imprint_fields.empty?
+
+          date_sf = main_imprint['c'] if main_imprint
+          date = get_date(date_sf, min, max, 'var_field', range_tolerance) if date_sf
+          return date
+        end
+
+        # Given single date string from any source field plus other parameters, returns either:
+        #  - usable date as integer; or
+        #  - nil
+        def get_date(string, min, max, type, range_tolerance)
+          the_date = string.strip
+
+          # Extract 3-4 character strings beginning with digits and, sometimes, ending with -
+          #  from varfield date strings
+          date_matcher = the_date.match(/\d{4}|\d-{2,3}|\d{2}-{1,2}|\d{3}-?/) if type == 'var_field'
+          the_date = date_matcher[0] if date_matcher
+
+          # convert to range based on date source
+          # fixed field indicates range with u
+          # var field uses -
+          if is_range?(the_date, type)
+            case type
+            when 'fixed_field'
+              to_replace = 'u'
+            when 'var_field'
+              to_replace = '-'
+            end
+            startdate = the_date.gsub(to_replace, '0').to_i
+            enddate = the_date.gsub(to_replace, '9').to_i
+
+            # 20uu is the only way to indicate sometime since 2000, but we don't
+            #   know if it was 2000-2009 or 2010-2019.
+            # However I'm making an assumption that anything we are recording in metadata that will
+            #   be transformed by MARC-to-Argot will not be happening in 2075 or some other ridiculous
+            #   point in the future.
+            # So, change 2099 range end date to the current year at time of transformation
+            enddate = Time.new.year if enddate == 2099
+
+            # ranges of over a certain number of years are pretty uninformative, so discard them.
+            usedate = (startdate + enddate)/2 if enddate - startdate <= range_tolerance
+          else
+            usedate = the_date.to_i
+          end
+          usedate = nil unless usable_date?(usedate, min, max)
+          return usedate
+        end
+
+        # Determines whether a given date value represents a range
+        #  e.g. 19uu, meaning 1900 to 1999
+        # Fixed field dates represent ambiguous part of date with 'u'
+        # Var field dates use '-'
+        def is_range?(str, type)
+          case type
+          when 'fixed_field'
+            return true if str =~ /\d+u+/
+            false
+          when 'var_field'
+            return true if str =~ /\d+-+/
+            false
+          end
+        end
+
+        # Says whether it's a usable date, given our min and max date settings
+        # 9999 is considered usable in general because it is a meaningful value in
+        #  the 008 date2
+        def usable_date?(str, min, max)
+          date = str.to_i
+          return true if date == 9999
+          return false unless date >= min
+          return false unless date <= max
+          true
+        end
+
+        # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+        # The rest of the methods handle the different date selection methods
+        #  for 008 dates, depending on the 008 date type code
+        # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+        
+        # Selects the fixed field date value to use when one is preferred
+        #  but the other is allowable. In the cases where this is needed,
+        #  sometimes 9999 counts as a valid date and sometimes not.
+        # valid_9999 = true means 9999 IS an acceptable/desired date here
+        # valid_9999 = false means 9999 is NOT and acceptable date here
+        def choose_ff_date(preferred_date, fallback_date, valid_9999)
+          chosen_year = preferred_date
+          chosen_year = nil if chosen_year == 9999 && valid_9999 == false
+          chosen_year = fallback_date if chosen_year == nil
+          chosen_year = nil if chosen_year == 9999 && valid_9999 == false
+          return chosen_year
+        end
+
+        # if both dates are usable, and are a sensible range, returns midpoint between them
+        # if both dates are usable, but do not express a sensible range, return date1
+        #  nonsensical range = date2 is earlier than or equal to date1
+        # if only one of the dates is usable, return it
+        def midpoint_or_usable(date1, date2)
+          return date1 if date2 == 9999
+          return (date1 + date2)/2 if date1 && date2 && date2 > date1
+          return date1 if date1 && date2 && date2 <= date1
+          return date1 if date1
+          return date2 if date2
+          return nil
+        end
+
+        # Handles the situation where we want date2, but have to be careful how it
+        #  interacts with date1. For example:
+        #  date type = d, date 1 = 1920, date 2 = 19uu means:
+        #    ceased serial
+        #    publication began in 1920
+        #    publication ended 1900-1999
+        #  Publication did not end before it began, so we need to adjust the range represented
+        #    by date2 to begin at 1920
+        #  Then we return the midpoint
+        def date2_accounting_for_date1_in_range(date1, date2, min, max)
+          date2 = date2.strip
+                    
+          usedate = date2.to_i unless is_range?(date2, 'fixed_field')
+          usedate = Time.new.year if usedate == 9999
+
+          if is_range?(date2, 'fixed_field') && date1
+            date2start = date2.gsub('u', '0').to_i
+            date2end = date2.gsub('u', '9').to_i
+            date2start = date1 if date2start < date1
+            usedate = (date2start + date2end)/2
+          end
+          usedate = nil unless usable_date?(usedate, min, max)
+          usedate
+        end
+
+      end
+    end
+  end
+end
+
+

--- a/lib/marc_to_argot/macros/shared_macros.rb
+++ b/lib/marc_to_argot/macros/shared_macros.rb
@@ -1,3 +1,4 @@
+require 'marc_to_argot/macros/shared/call_numbers'
 require 'marc_to_argot/macros/shared/edition'
 require 'marc_to_argot/macros/shared/helpers'
 require 'marc_to_argot/macros/shared/imprint'
@@ -6,6 +7,7 @@ require 'marc_to_argot/macros/shared/names'
 require 'marc_to_argot/macros/shared/notes'
 require 'marc_to_argot/macros/shared/physical_description'
 require 'marc_to_argot/macros/shared/physical_media'
+require 'marc_to_argot/macros/shared/publication_year'
 require 'marc_to_argot/macros/shared/resource_type'
 require 'marc_to_argot/macros/shared/series_statement'
 require 'marc_to_argot/macros/shared/subject_genre'
@@ -15,7 +17,6 @@ require 'marc_to_argot/macros/shared/upc'
 require 'marc_to_argot/macros/shared/urls'
 require 'marc_to_argot/macros/shared/vernacular'
 require 'marc_to_argot/macros/shared/work_entry'
-require 'marc_to_argot/macros/shared/call_numbers'
 
 require 'set'
 
@@ -25,6 +26,7 @@ module MarcToArgot
     # defined here, and overriden in institution-specific modules in the
     # same namespace.
     module Shared
+      include CallNumbers
       include Edition
       include Helpers
       include Imprint
@@ -32,6 +34,7 @@ module MarcToArgot
       include Names
       include Notes
       include PhysicalDescription
+      include PublicationYear
       include PhysicalMedia
       include ResourceType
       include SeriesStatement
@@ -42,7 +45,6 @@ module MarcToArgot
       include Urls
       include Vernacular
       include WorkEntry
-      include CallNumbers
 
       # values to look for in the 856 that indicate
       # a record has online access.

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.2.2'.freeze
+  VERSION = '0.2.3'.freeze
 end

--- a/spec/ext/marc/record_spec.rb
+++ b/spec/ext/marc/record_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe MARC::Record do
+
+  def create_rec
+    rec = MARC::Record.new
+    cf008val = ''
+    40.times { cf008val << ' ' }
+    rec << MARC::ControlField.new('008', cf008val)
+    rec
+  end
+
+  describe '.date_type' do
+    it 'returns DateType from 008' do
+      rec = create_rec
+      rec['008'].value[6] = 's'
+
+      result = rec.date_type
+      expect(result).to eq('s')
+    end
+
+    it 'fails gracefully if no 008' do
+      rec = MARC::Record.new
+
+      result = rec.date_type
+      expect(result).to be_nil
+    end
+
+    it 'fails gracefully if 008 has no byte 06' do
+      rec = MARC::Record.new
+      rec << MARC::ControlField.new('008', '   ')
+      result = rec.date_type
+      expect(result).to be_nil
+    end
+
+  end
+
+  describe '.date1' do
+    it 'returns Date1 (bytes 7-10) from 008' do
+      rec = create_rec
+      rec['008'].value[7..10] = '2018'
+
+      result = rec.date1
+      expect(result).to eq('2018')
+    end
+  end
+
+  describe '.date2' do
+    it 'returns Date1 (bytes 11-14) from 008' do
+      rec = create_rec
+      rec['008'].value[11..14] = '2007'
+
+      result = rec.date2
+      expect(result).to eq('2007')
+    end
+  end
+
+end

--- a/spec/macros/shared/publication_year_spec.rb
+++ b/spec/macros/shared/publication_year_spec.rb
@@ -1,0 +1,459 @@
+# coding: iso-8859-1
+require 'spec_helper'
+#require_relative '../../../lib/marc_to_argot/macros/shared/publication_year'
+include MarcToArgot::Macros::Shared::PublicationYear
+
+describe MarcToArgot do
+  include Util::TrajectRunTest
+
+  def make_rec
+    rec = MARC::Record.new
+    rec << MARC::ControlField.new('008', ' ' * 40)
+    return rec
+  end
+
+  describe MarcToArgot::Macros::Shared::PublicationYear do
+    context 'DateType = b' do
+      context 'AND no 260/4 date' do
+        it '(MTA) does not set date' do
+          rec = make_rec
+          val = rec['008'].value
+          val[6] = 'b'
+          val[7..10] = '1975'
+          rec['008'].value = val
+          argot = run_traject_on_record('unc', rec)
+          expect(argot['publication_year']).to be_nil
+        end
+      end
+
+      context 'AND 260/4 date' do
+        it '(MTA) sets date from 260/4' do
+          rec = make_rec
+          val = rec['008'].value
+          val[6] = 'b'
+          val[7..10] = '1975'
+          rec['008'].value = val
+          rec << MARC::DataField.new('260', ' ',  ' ', ['c', '1999'])
+          argot = run_traject_on_record('unc', rec)
+          expect(argot['publication_year']).to eq([1999])
+        end
+      end
+    end
+
+    context 'DateType = c' do
+      it '(MTA) sets from usable date2 if present' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'c20129999'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([9999])
+      end
+      it '(MTA) does not set from unusable date2' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'c19002uuu'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to be_nil
+      end
+    end
+
+    context 'DateType = d' do
+      it '(MTA) sets from usable date2 if present' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'd    1949'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1949])
+      end
+      it '(MTA) sets from date2 range not beginning before date1' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'd194519uu'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1972])
+      end
+      it '(MTA) does not fall over if date2 blank' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'd1945    '
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to be_nil
+      end
+      it '(MTA) sets current year if date2 = 9999' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'd19459999'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([Time.new.year])
+      end
+    end
+
+    context 'DateType = e' do
+      context 'AND no 260/4 date' do
+        it '(MTA) sets from usable date1' do
+          rec = make_rec
+          rec['008'].value[6..14] = 'e20120215'
+          argot = run_traject_on_record('unc', rec)
+          expect(argot['publication_year']).to eq([2012])
+        end
+        it '(MTA) does not set from unusable date1' do
+          rec = make_rec
+          rec['008'].value[6..14] = 'e||||0215'
+          argot = run_traject_on_record('unc', rec)
+          expect(argot['publication_year']).to be_nil
+        end
+      end
+    end
+
+    context 'DateType = i' do
+      it '(MTA) sets from usable date1' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'i19101950'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1910])
+      end
+    end
+
+    context 'DateType = k' do
+      it '(MTA) sets from usable date1' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'k19101950'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1910])
+      end
+    end
+
+    context 'DateType = m' do
+      it '(MTA) sets from non-9999 date2' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'm19662000'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([2000])
+      end
+      it '(MTA) sets from date1 if date2 = 9999' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'm19669999'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1966])
+      end
+      it '(MTA) sets from date1 if date2 otherwise unusable' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'm19842uuu'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1984])
+      end
+    end
+
+    context 'DateType = n' do
+      it '(MTA) if usable range, sets midpoint' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'n18501900'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1875])
+      end
+      it '(MTA) uses date1 if both dates present but equal or date1 later' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'n19661966'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1966])
+        rec['008'].value[6..14] = 'n20001950'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([2000])
+      end
+      it '(MTA) sets from date1 if date2 unusable' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'n19842uuu'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1984])
+      end
+    end
+
+    context 'DateType = p' do
+      it '(MTA) sets from non-9999 date2' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'p20182000'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([2000])
+      end
+      it '(MTA) sets from date1 if date2 = 9999' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'p19669999'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1966])
+      end
+      it '(MTA) sets from date1 if date2 otherwise unusable' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'p1984uuuu'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1984])
+      end
+    end
+
+    context 'DateType = q' do
+      it '(MTA) if usable range, sets midpoint' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'q10001199'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1099])
+      end
+      it '(MTA) uses date1 if both dates present but equal or date1 later' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'q19661966'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1966])
+        rec['008'].value[6..14] = 'q20001950'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([2000])
+      end
+      it '(MTA) sets from date2 if date1 unusable' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'q    1932'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1932])
+      end
+    end
+
+    context 'DateType = r' do
+      it '(MTA) sets from non-9999 date2' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'r20182000'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([2000])
+      end
+      it '(MTA) sets from date1 if date2 = 9999' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'r19669999'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1966])
+      end
+      it '(MTA) sets from date1 if date2 otherwise unusable' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'r1984uuuu'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1984])
+      end
+    end
+
+    context 'DateType = s' do
+      context 'AND no 260/4 date' do
+        it '(MTA) sets from usable full year date1' do
+          rec = make_rec
+          rec['008'].value[6..14] = 's2012    '
+          argot = run_traject_on_record('unc', rec)
+          expect(argot['publication_year']).to eq([2012])
+        end
+        it '(MTA) sets from usable date1 decade range' do
+          rec = make_rec
+          rec['008'].value[6..14] = 's201u    '
+          argot = run_traject_on_record('unc', rec)
+          expect(argot['publication_year']).to eq([2014])
+        end
+        it '(MTA) sets from usable date1 century range' do
+          rec = make_rec
+          rec['008'].value[6..14] = 's19uu    '
+          argot = run_traject_on_record('unc', rec)
+          expect(argot['publication_year']).to eq([1949])
+        end
+        it '(MTA) sets from usable date1 century range (this century)' do
+          rec = make_rec
+          rec['008'].value[6..14] = 's20uu    '
+          argot = run_traject_on_record('unc', rec)
+          expect(argot['publication_year']).to eq([(2000 + Time.new.year)/2])
+        end
+        it '(MTA) does not consider date1 millenium range usable' do
+          rec = make_rec
+          rec['008'].value[6..14] = 's1uuu    '
+          argot = run_traject_on_record('unc', rec)
+          expect(argot['publication_year']).to be_nil
+        end
+      end
+    end
+
+    context 'DateType = t' do
+      it '(MTA) sets from usable date1' do
+        rec = make_rec
+        rec['008'].value[6..14] = 't2012    '
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([2012])
+      end
+    end
+
+    context 'DateType = u' do
+      it '(MTA) sets from usable date2 if present --- 9999 is considered usable' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'u20129999'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([9999])
+      end
+      it '(MTA) sets from usable date1 if no usable date2' do
+        rec = make_rec
+        rec['008'].value[6..14] = 'u19002uuu'
+        argot = run_traject_on_record('unc', rec)
+        expect(argot['publication_year']).to eq([1900])
+      end
+    end
+
+    describe 'usable_date?' do
+      it 'returns true if 4 digits and in range' do
+        v = usable_date?('1997', 500, 2024)
+        expect(v).to eq(true)
+      end
+
+      it 'returns true if fewer than 4 digits, but in range' do
+        v = usable_date?('666 ', 500, 2024)
+        expect(v).to eq(true)
+      end
+
+      it 'returns false if 4 digits and out of range' do
+        v = usable_date?('6754', 500, 2024)
+        expect(v).to eq(false)
+      end
+
+      it 'returns false if uuuu' do
+        v = usable_date?('uuuu', 500, 2024)
+        expect(v).to eq(false)
+      end
+
+      it 'returns true if 9999' do
+        v = usable_date?('9999', 500, 2024)
+        expect(v).to eq(true)
+      end
+    end
+
+    describe 'is_range?' do
+      it 'works for fixed field u dates' do
+        v1 = is_range?('1997', 'fixed_field')
+        v2 = is_range?('199u', 'fixed_field')
+        v3 = is_range?('19uu', 'fixed_field')
+        v4 = is_range?('uuuu', 'fixed_field')
+        v5 = is_range?('198|', 'fixed_field')
+        v6 = is_range?('66u|', 'fixed_field')
+        expect(v1).to eq(false)
+        expect(v2).to eq(true)
+        expect(v3).to eq(true)
+        expect(v4).to eq(false)
+        expect(v5).to eq(false)
+        expect(v6).to eq(true)
+      end
+      
+      it 'works for variable field u dates' do
+        v1 = is_range?('1997', 'var_field')
+        v2 = is_range?('199-', 'var_field')
+        v3 = is_range?('19--', 'var_field')
+        v4 = is_range?('1---', 'var_field')
+        v5 = is_range?('198?', 'var_field')
+        expect(v1).to eq(false)
+        expect(v2).to eq(true)
+        expect(v3).to eq(true)
+        expect(v4).to eq(true)
+        expect(v5).to eq(false)
+      end
+    end
+
+    describe 'choose_ff_date' do
+      it 'returns preferred date if present' do
+        d = choose_ff_date(1999, 1995, false)
+        expect(d).to eq(1999)
+      end
+      it 'returns fallback date if preferred date not present' do
+        d = choose_ff_date(nil, 1995, false)
+        expect(d).to eq(1995)
+      end
+      it 'returns fallback date if preferred date is invalid 9999' do
+        d = choose_ff_date(9999, 1995, false)
+        expect(d).to eq(1995)
+      end
+      it 'returns nil if both dates are missing or an invalid 9999' do
+        d = choose_ff_date(9999, nil, false)
+        expect(d).to be_nil
+      end
+      it 'returns 9999 from preferred date if 9999 is valid' do
+        d = choose_ff_date(9999, 1980, true)
+        expect(d).to eq(9999)
+      end
+    end
+
+    describe 'midpoint_or_usable' do
+      it 'returns midpoint between dates if both dates present' do
+        d = midpoint_or_usable(1850, 1900)
+        expect(d).to eq(1875)
+      end
+      it 'does not consider 9999 a usable date' do
+        d = midpoint_or_usable(1850, 9999)
+        expect(d).to eq(1850)
+      end
+      it 'chooses single date if only one is usable' do
+        d = midpoint_or_usable(1894, nil)
+        expect(d).to eq(1894)
+      end
+      it 'chooses single date if both dates are identical' do
+        d = midpoint_or_usable(1894, 1894)
+        expect(d).to eq(1894)
+      end
+    end
+    
+    describe 'get_date (fixed fields)' do
+      it 'treats uncertain date as range' do
+        d = get_date('19uu', 500, 2024, 'fixed_field', 500)
+        expect(d).to eq(1949)
+      end
+
+      it 'populates usable non-range date' do
+        d = get_date('666', 500, 2024, 'fixed_field', 500)
+        expect(d).to eq(666)
+      end
+
+      it 'returns nil if date is not usable' do
+        d = get_date('9876', 500, 2024, 'fixed_field', 500)
+        expect(d).to be_nil
+      end
+    end
+    
+    describe 'get_date (var fields)' do
+      it 'treats uncertain date as range' do
+        d = get_date('197-', 500, 2024, 'var_field', 500)
+        expect(d).to eq(1974)
+      end
+
+      it 'populates usable non-range date' do
+        d = get_date('666', 500, 2024, 'var_field', 500)
+        expect(d).to eq(666)
+      end
+
+      it 'returns nil if date is not usable' do
+        d = get_date('9876', 500, 2024, 'var_field', 500)
+        expect(d).to be_nil
+      end
+
+      it 'extracts 1999 from \'c1999\'' do
+        d = get_date('c1999', 500, 2024, 'var_field', 500)
+        expect(d).to eq(1999)
+      end
+
+      it 'extracts 2018 from \'-2018\'' do
+        d = get_date('-2018', 500, 2024, 'var_field', 500)
+        expect(d).to eq(2018)
+      end
+
+      it 'extracts 1974 from \'197--\'' do
+        d = get_date('197--', 500, 2024, 'var_field', 500)
+        expect(d).to eq(1974)
+      end
+
+      it 'extracts 1974 from \'[197-?]\'' do
+        d = get_date('[197-?]', 500, 2024, 'var_field', 500)
+        expect(d).to eq(1974)
+      end
+      it 'extracts 2017 from \'[2017];©2018\'' do
+        d = get_date('[2017];©2018', 500, 2024, 'var_field', 500)
+        expect(d).to eq(2017)
+      end
+      it 'extracts 1950 from \'[between 1950 and 1959?]\'' do
+        d = get_date('[between 1950 and 1959?]', 500, 2024, 'var_field', 500)
+        expect(d).to eq(1950)
+      end
+      it 'extracts 2014 from \'-December 16, 2014.\'' do
+        d = get_date('-December 16, 2014.', 500, 2024, 'var_field', 500)
+        expect(d).to eq(2014)
+      end
+      it 'returns nil when there is no date match' do
+        d = get_date('[n.d.]', 500, 2024, 'var_field', 500)
+        expect(d).to be_nil
+      end
+    end
+  end
+end

--- a/spec/util.rb
+++ b/spec/util.rb
@@ -126,5 +126,12 @@ module Util
     def run_traject_json(collection, file, extension = 'xml')
       JSON.parse(run_traject(collection, file, extension))
     end
+
+    # Runs traject on a single MARC record and returns JSON
+    def run_traject_on_record(collection, record)
+      indexer = load_indexer(collection, 'mrc')
+      indexer.map_record(record)
+    end
+
   end
 end


### PR DESCRIPTION
- Creates our own macro for populating `publication_year` instead of using Traject's marc_publication_date, which was failing to populate this field in way too many records. 

Draft release: https://github.com/trln/marc-to-argot/releases/edit/untagged-943e4239814cfa7cdfb0