### PR TITLE
Td 804 index note cited in

### DIFF
--- a/lib/data/unc/overrides.yml
+++ b/lib/data/unc/overrides.yml
@@ -5,10 +5,10 @@
 - institution
 - items
 - local_id
+- names
 - note_local
 - oclc_number
 - resource_type
 - rollup_id
 - sersol_number
 - url
-- names

--- a/lib/data/unc/traject_config.rb
+++ b/lib/data/unc/traject_config.rb
@@ -184,7 +184,7 @@ end
 # URLs
 ######
 each_record do |rec, cxt|
-  url(rec, cxt)
+  url_unc(rec, cxt)
 end
 
 

--- a/lib/marc_to_argot/macros/unc/urls.rb
+++ b/lib/marc_to_argot/macros/unc/urls.rb
@@ -4,7 +4,7 @@ module MarcToArgot
       module Urls
         include MarcToArgot::Macros::Shared::Urls
 
-        def url(rec, cxt)
+        def url_unc(rec, cxt)
           urls = []
           Traject::MarcExtractor.cached("856uy3").each_matching_line(rec) do |field, spec, extractor|
             url = {}
@@ -35,7 +35,7 @@ module MarcToArgot
             urls << url.to_json
           end
 
-          cxt.output_hash['url'] = urls
+          cxt.output_hash['url'] = urls unless urls.empty?
         end
 
 
@@ -72,6 +72,7 @@ module MarcToArgot
 
         def is_proxied?(url)
           return true if url.start_with?('http://libproxy.lib.unc.edu/login?url=')
+          return false
         end
 
         def template_proxy(url)

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.2.6'.freeze
+  VERSION = '0.2.7'.freeze
 end

--- a/spec/macros/shared/notes_spec.rb
+++ b/spec/macros/shared/notes_spec.rb
@@ -44,27 +44,27 @@ describe MarcToArgot::Macros::Shared::Notes do
   it '(MTA) sets note_access_restrictions' do
     result = note_access_restrictions['note_access_restrictions']
     expect(result).to eq(
-      ['A label: Access restricted to subscribing institutions.']
-    )
+                        ['A label: Access restricted to subscribing institutions.']
+                      )
   end
 
   it '(MTA) sets note_admin_history' do
     result = note_admin_history['note_admin_history']
     expect(result).to eq(
-      ['A note about admin history.']
-    )
+                        ['A note about admin history.']
+                      )
   end
 
   it '(MTA) sets note_binding' do
     result = note_binding['note_binding']
     expect(result).to eq(
-      [{'value'=>'Perfect bound softcover. Four-color offset lithography. '\
-        'Illustrated paper wrappers with flaps. Housed in foldout die-cut box '\
-        'with gold foil origami crane inserted into cover slot. Signed and numbered '\
-        "by the artist on book's front cover flap -- "\
-        'Description from http://vampandtramp.com/finepress/s/clarissa-sligh.html'},
-       {'label'=>'A label', 'value'=>'A note about the binding.'}]
-    )
+                        [{'value'=>'Perfect bound softcover. Four-color offset lithography. '\
+                                   'Illustrated paper wrappers with flaps. Housed in foldout die-cut box '\
+                                   'with gold foil origami crane inserted into cover slot. Signed and numbered '\
+                                   "by the artist on book's front cover flap -- "\
+                                   'Description from http://vampandtramp.com/finepress/s/clarissa-sligh.html'},
+                         {'label'=>'A label', 'value'=>'A note about the binding.'}]
+                      )
   end
 
   it '(MTA) does NOT set note_binding from field with non-whitelisted $5 value' do
@@ -76,7 +76,10 @@ describe MarcToArgot::Macros::Shared::Notes do
     result = note_cited_in1['note_cited_in']
     expect(result).to eq(
                         [
-                          'Chemical abstracts ISSN 0009-2258 1968-1986.'
+                          {
+                            "value" => "Chemical abstracts ISSN 0009-2258 1968-1986.",
+                            "indexed_value" => "Chemical abstracts 1968-1986."
+                          }
                         ]
                       )
   end
@@ -85,11 +88,26 @@ describe MarcToArgot::Macros::Shared::Notes do
     result = note_cited_in2['note_cited_in']
     expect(result).to eq(
                         [
-                          'Arcadelt, Terzo libro: RISM A/I, A1374.',
-                          'Arcadelt, Terzo libro: RISM B/I, 1539-23.',
-                          'Arcadelt, Secondo libro: RISM A/I, A1371.',
-                          'Arcadelt, Quinto libro: RISM A/I, A1382.',
-                          'Arcadelt, Quinto libro: RISM B/I, B1544-16.'
+                          {
+                            "label" => "Arcadelt, Terzo libro",
+                            "value" => "RISM A/I, A1374."
+                          },
+                          {
+                            "label" => "Arcadelt, Terzo libro",
+                            "value" => "RISM B/I, 1539-23."
+                          },
+                          {
+                            "label" => "Arcadelt, Secondo libro",
+                            "value" => "RISM A/I, A1371."
+                          },
+                          {
+                            "label" => "Arcadelt, Quinto libro",
+                            "value" => "RISM A/I, A1382."
+                          },
+                          {
+                            "label" => "Arcadelt, Quinto libro",
+                            "value" => "RISM B/I, B1544-16."
+                          }
                         ]
                       )
   end
@@ -97,29 +115,29 @@ describe MarcToArgot::Macros::Shared::Notes do
   it '(MTA) sets note_biographical' do
     result = note_admin_history['note_biographical']
     expect(result).to eq(
-      ['A unspecified Biographical or Historical Data note.', 'A biographical note.']
-    )
+                        ['A unspecified Biographical or Historical Data note.', 'A biographical note.']
+                      )
   end
 
   it '(MTA) sets note_copy_version' do
     result = note_copy_version['note_copy_version']
     expect(result).to eq(
-      ['A note about copy version.', 'A label: Another note about copy version.']
-    )
+                        ['A note about copy version.', 'A label: Another note about copy version.']
+                      )
   end
 
   it '(MTA) sets note_data_quality' do
     result = note_data_quality['note_data_quality']
     expect(result).to eq(
-      ['Attribute accuracy: Estimated to be 98.5%. -- Village names compared to source map -- all match, '\
-        'therefore errors are possible only if source maps are incorrect.',
-       'Logical consistency: Node-to-line, line-to-area topological relationships maintained. '\
-       'Line and area attributes maintained. GRASS 4.0 program "v.support" checks topological relationships.',
-       'Horizontal position accuracy: The accuracy of this data is based upon the use of the source maps '\
-       '... [subfield  --  shortened in this example]',
-       'Cloud cover: 8.42%',
-       'Other data details: All incorporated limits shown on USGS quads were digitized.']
-    )
+                        ['Attribute accuracy: Estimated to be 98.5%. -- Village names compared to source map -- all match, '\
+                         'therefore errors are possible only if source maps are incorrect.',
+                         'Logical consistency: Node-to-line, line-to-area topological relationships maintained. '\
+                         'Line and area attributes maintained. GRASS 4.0 program "v.support" checks topological relationships.',
+                         'Horizontal position accuracy: The accuracy of this data is based upon the use of the source maps '\
+                         '... [subfield  --  shortened in this example]',
+                         'Cloud cover: 8.42%',
+                         'Other data details: All incorporated limits shown on USGS quads were digitized.']
+                      )
   end
 
   it '(MTA) sets note_described_by with Finding aid label' do
@@ -163,119 +181,119 @@ describe MarcToArgot::Macros::Shared::Notes do
   it '(MTA) sets note_dissertation' do
     result = note_dissertation['note_dissertation']
     expect(result).to eq(
-      ['Thesis (doctoral) - Universität, Neuchâtel, 1998.',
-       'Thesis/disseration--Bremen International Graduate School of Social Sciences, 2008',
-       'Thesis--Ph.D--University of North Carolina at Chapel Hill.',
-       'Recital document--Master of Music in Performance and Vocal Pedagogy--University of Texas at San Antonio, 2012.',
-       'Ph. D.--University of North Carolina, 1976']
-    )
+                        ['Thesis (doctoral) - Universität, Neuchâtel, 1998.',
+                         'Thesis/disseration--Bremen International Graduate School of Social Sciences, 2008',
+                         'Thesis--Ph.D--University of North Carolina at Chapel Hill.',
+                         'Recital document--Master of Music in Performance and Vocal Pedagogy--University of Texas at San Antonio, 2012.',
+                         'Ph. D.--University of North Carolina, 1976']
+                      )
   end
 
   it '(MTA) sets note_file_type' do
     result = note_file_type['note_file_type']
     expect(result).to eq(
-      ['PDF, Excel, and ASCII files.']
-    )
+                        ['PDF, Excel, and ASCII files.']
+                      )
   end
 
   it '(MTA) sets note_former_title' do
     result = note_former_title['note_former_title']
     expect(result).to eq(
-      ['Resource originally known as NetLibrary, owned and maintained by NetLibrary, '\
-       'a division of OCLC, <Feb. 8, 2010>- ; resource purchased by EBSCOhost and relaunched '\
-       'as "ebook Collection", <July 22, 2011>-']
-    )
+                        ['Resource originally known as NetLibrary, owned and maintained by NetLibrary, '\
+                         'a division of OCLC, <Feb. 8, 2010>- ; resource purchased by EBSCOhost and relaunched '\
+                         'as "ebook Collection", <July 22, 2011>-']
+                      )
   end
 
   it '(MTA) sets note_general' do
     result = note_general['note_general']
     expect(result).to eq([
-      {'value' => 'Translation is based on a photocopy of the original MS. in the '\
-                  'Library of Pembroke College, Oxford.'},
-      {'value' => 'Number of references: 36 references.',
-      'indexed' => 'false'},
-      {'value' => 'Bibliography : p. 81-83. Number of references: 52.',
-      'indexed' => 'false'},
-      {'label' => '1st-4th works',
-       'value' => 'recorded 2013 January 25-27 St. Mary\'s Church, Chilham, Kent.',
-       'indexed' => 'false'},
-      {'label' => '5th work',
-       'value' => 'recorded 2013 January 31 No. 2 Studio, Abbey Road, London.',
-       'indexed' => 'false'},
-      {'value' => 'Recorded June 11-18, 1981, Corbett Auditorium, College-Conservatory of Music, University of Cincinnati.',
-       'indexed' => 'false'},
-      {'value' => '"The professional bulletin for Army engineers."',
-       'indexed' => 'false'},
-      {'label' => 'For audience(s)',
-       'value' => 'Scholarly & Professional (source: IEEE Computer Society Press)',
-       'indexed' => 'false'},
-      {'label' => 'For grade(s)',
-       'value' => '4.5.',
-       'indexed' => 'false'},
-      {'label' => 'Workbook: For age(s)',
-       'value' => '3 to 7.',
-       'indexed' => 'false'},
-      {'label' => 'For grade(s)',
-       'value' => '7-12. (source: Brodart)',
-       'indexed' => 'false'},
-      {'label' => 'For audience(s)',
-       'value' => 'Older adults; younger persons with disabilities.',
-       'indexed' => 'false'},
-      {'value' => '"The non-OECD countries in this report comprise ... central and Eastern European '\
-                  'countries (CEECs), major New Indepenent States (NIS), and China, Brazil, and India ..."'},
-      {'label' => 'Geographic coverage',
-       'value' => 'Asia-Pacific ; Africa ; Near East ; Americas ; Europe ; Argentina ; Uruguay ; Brazil ; Chile ; Peru.'},
-      {'label' => 'Reading program: 2017 addition to',
-       'value' => 'Accelerated Reader -- Interest level: Grades 5-8 -- Reading level: 4.9 '\
-                  '-- Title points: 10 -- Quiz 161076 -- English fiction.',
-       'indexed_value' => 'Accelerated Reader'},
-      {'value' => 'CE credits available from Psychotherapy.net'},
-      {'label' => 'Funding details',
-       'value' => 'Headquarters, U.S. Army Corps of Engineers. 4A162784, AT 45, FF-XS5.'},
-      {'label' => 'Text',
-       'value' => 'Latin'},
-      {'label' => 'Introduction and notes',
-       'value' => 'German'},
-      {'label' => 'Documentation',
-      'value' => 'IPEDS peer analysis system user manual, self guided tutorials.',
-      'indexed' => 'false'},
-      {'value' => 'Accompanied by user\'s manual (in English and French). Title on manual: '\
-                  'Mayer international auction records on CD-ROM.',
-      'indexed' => 'false'},
-      {'label' => 'Paintings, calligraphies, seal carvings',
-       'value' => 'Exhibited: University Museum and Art Gallery, The University of Hong Kong, '\
-                  'sponsored by Mr. Frankie W., October 29, 2004-December 9, 2004.'},
-      {'value' => '"Published in conjunction with the exhibition Wiener Werkstätte 1903-1932 : '\
-                  'the luxury of beauty, Neue Galerie New York, October 26, 2017-'\
-                  'January 29, 2018" (title page verso).'},
-      {'value' => 'Academy Awards, 2003: Best Documentary, Features (Michael Moore, Michael Donovan)'},
-      {'value' => 'Cannes Film Festival, 2002: 55th Anniversary Prize (Michael Moore)'},
-      {'label' => 'Ana',
-      'value' => 'Dai 150-kai Akutagawa-shō, 2014'}
-    ])
+                           {'value' => 'Translation is based on a photocopy of the original MS. in the '\
+                                       'Library of Pembroke College, Oxford.'},
+                           {'value' => 'Number of references: 36 references.',
+                            'indexed' => 'false'},
+                           {'value' => 'Bibliography : p. 81-83. Number of references: 52.',
+                            'indexed' => 'false'},
+                           {'label' => '1st-4th works',
+                            'value' => 'recorded 2013 January 25-27 St. Mary\'s Church, Chilham, Kent.',
+                            'indexed' => 'false'},
+                           {'label' => '5th work',
+                            'value' => 'recorded 2013 January 31 No. 2 Studio, Abbey Road, London.',
+                            'indexed' => 'false'},
+                           {'value' => 'Recorded June 11-18, 1981, Corbett Auditorium, College-Conservatory of Music, University of Cincinnati.',
+                            'indexed' => 'false'},
+                           {'value' => '"The professional bulletin for Army engineers."',
+                            'indexed' => 'false'},
+                           {'label' => 'For audience(s)',
+                            'value' => 'Scholarly & Professional (source: IEEE Computer Society Press)',
+                            'indexed' => 'false'},
+                           {'label' => 'For grade(s)',
+                            'value' => '4.5.',
+                            'indexed' => 'false'},
+                           {'label' => 'Workbook: For age(s)',
+                            'value' => '3 to 7.',
+                            'indexed' => 'false'},
+                           {'label' => 'For grade(s)',
+                            'value' => '7-12. (source: Brodart)',
+                            'indexed' => 'false'},
+                           {'label' => 'For audience(s)',
+                            'value' => 'Older adults; younger persons with disabilities.',
+                            'indexed' => 'false'},
+                           {'value' => '"The non-OECD countries in this report comprise ... central and Eastern European '\
+                                       'countries (CEECs), major New Indepenent States (NIS), and China, Brazil, and India ..."'},
+                           {'label' => 'Geographic coverage',
+                            'value' => 'Asia-Pacific ; Africa ; Near East ; Americas ; Europe ; Argentina ; Uruguay ; Brazil ; Chile ; Peru.'},
+                           {'label' => 'Reading program: 2017 addition to',
+                            'value' => 'Accelerated Reader -- Interest level: Grades 5-8 -- Reading level: 4.9 '\
+                                       '-- Title points: 10 -- Quiz 161076 -- English fiction.',
+                            'indexed_value' => 'Accelerated Reader'},
+                           {'value' => 'CE credits available from Psychotherapy.net'},
+                           {'label' => 'Funding details',
+                            'value' => 'Headquarters, U.S. Army Corps of Engineers. 4A162784, AT 45, FF-XS5.'},
+                           {'label' => 'Text',
+                            'value' => 'Latin'},
+                           {'label' => 'Introduction and notes',
+                            'value' => 'German'},
+                           {'label' => 'Documentation',
+                            'value' => 'IPEDS peer analysis system user manual, self guided tutorials.',
+                            'indexed' => 'false'},
+                           {'value' => 'Accompanied by user\'s manual (in English and French). Title on manual: '\
+                                       'Mayer international auction records on CD-ROM.',
+                            'indexed' => 'false'},
+                           {'label' => 'Paintings, calligraphies, seal carvings',
+                            'value' => 'Exhibited: University Museum and Art Gallery, The University of Hong Kong, '\
+                                       'sponsored by Mr. Frankie W., October 29, 2004-December 9, 2004.'},
+                           {'value' => '"Published in conjunction with the exhibition Wiener Werkstätte 1903-1932 : '\
+                                       'the luxury of beauty, Neue Galerie New York, October 26, 2017-'\
+                                       'January 29, 2018" (title page verso).'},
+                           {'value' => 'Academy Awards, 2003: Best Documentary, Features (Michael Moore, Michael Donovan)'},
+                           {'value' => 'Cannes Film Festival, 2002: 55th Anniversary Prize (Michael Moore)'},
+                           {'label' => 'Ana',
+                            'value' => 'Dai 150-kai Akutagawa-shō, 2014'}
+                         ])
   end
 
   it '(MTA) sets note_issuance' do
     result = note_issuance['note_issuance']
     expect(result).to eq(
-      ['Conference for 1964 sponsored by the Board of Managers of the Nemours Foundation.',
-       'Conferences for <1965- > organized by the Delaware Commission for the Aging.']
-    )
+                        ['Conference for 1964 sponsored by the Board of Managers of the Nemours Foundation.',
+                         'Conferences for <1965- > organized by the Delaware Commission for the Aging.']
+                      )
   end
 
   it '(MTA) sets note_local' do
     result = note_local['note_local']
     expect(result).to eq(
-      [{'label' => 'c. 1',
-        'value' => 'Inscribed: "Benson R. Wilcox"--Fly leaf.'},
-      {'label' => 'Source of acquisition',
-         'value' => 'Presented by Benson R. Wilcox (Gift : 2010 : Health Sciences Library, c. 1)',
-         'indexed_value' => 'Presented by Benson R. Wilcox'},
-        {'label' => 'Ownership history: c. 1',
-         'value' => 'Bookplate: "Ex Libris Benson R. Wilcox M.D."--Inside front cover.'},
-        {'value' => 'RBC PQ4315.58 .R7 1896 c. 1: RBC: Bound in ivory paper yapp fore-edges deckle edges notations and markings throughout.'}
-      ]
-    )
+                        [{'label' => 'c. 1',
+                          'value' => 'Inscribed: "Benson R. Wilcox"--Fly leaf.'},
+                         {'label' => 'Source of acquisition',
+                          'value' => 'Presented by Benson R. Wilcox (Gift : 2010 : Health Sciences Library, c. 1)',
+                          'indexed_value' => 'Presented by Benson R. Wilcox'},
+                         {'label' => 'Ownership history: c. 1',
+                          'value' => 'Bookplate: "Ex Libris Benson R. Wilcox M.D."--Inside front cover.'},
+                         {'value' => 'RBC PQ4315.58 .R7 1896 c. 1: RBC: Bound in ivory paper yapp fore-edges deckle edges notations and markings throughout.'}
+                        ]
+                      )
   end
 
   it '(MTA) does NOT set note_local from field with non-whitelisted $5 value' do
@@ -286,18 +304,18 @@ describe MarcToArgot::Macros::Shared::Notes do
   it '(MTA) sets note_methodology' do
     result = note_methodology['note_methodology']
     expect(result).to eq(
-      ['Samples from 319 quadrangles (1 degree x 2 degrees) beginning in 1976 and ending in 1980; '\
-       'four main sample types represented: stream sediment, soil, surface water, and ground water. '\
-       'Each sample analyzed for uranium and as many as 58 other elements including sulfate.']
-    )
+                        ['Samples from 319 quadrangles (1 degree x 2 degrees) beginning in 1976 and ending in 1980; '\
+                         'four main sample types represented: stream sediment, soil, surface water, and ground water. '\
+                         'Each sample analyzed for uranium and as many as 58 other elements including sulfate.']
+                      )
   end
 
   it '(MTA) sets note_numbering' do
     result = note_numbering['note_numbering']
     expect(result).to include(
-      'Publication suspended after v. 10, no. 3, 1943; '\
-      'resumed Mar. 1948- Cf. Union List of Serials.'
-    )
+                        'Publication suspended after v. 10, no. 3, 1943; '\
+                        'resumed Mar. 1948- Cf. Union List of Serials.'
+                      )
   end
 
   it '(MTA) sets note_organization' do
@@ -326,9 +344,9 @@ describe MarcToArgot::Macros::Shared::Notes do
                            'value' => 'Diocesan Library, Episcopal Diocese of Western North '\
                                       'Carolina, P. O. Box 368, Black Mountain, N.C. 28711.',
                            'indexed' => 'false'},
-                           {'label' => 'Microfilm: Duplicates held by',
+                          {'label' => 'Microfilm: Duplicates held by',
                            'value' => 'Church of Jesus Christ of the Latter-day Saints. '\
-                           'Family History Center, Greensboro, N.C.',
+                                      'Family History Center, Greensboro, N.C.',
                            'indexed' => 'false'}])
   end
 
@@ -387,8 +405,8 @@ describe MarcToArgot::Macros::Shared::Notes do
   it '(MTA) sets note_reproduction from 534' do
     result = note_reproduction_02['note_reproduction']
     expect(result).to eq([{'label' => 'Original version',
-                          'value' => 'New York : Published by Currier & Ives, c1892. Copyright 1892 by Currier & Ives, N.Y.',
-                          'indexed' => 'false'},
+                           'value' => 'New York : Published by Currier & Ives, c1892. Copyright 1892 by Currier & Ives, N.Y.',
+                           'indexed' => 'false'},
                           {'label' => 'Original version in',
                            'value' => 'Bry, Theodor de, 1528-1598. Admiranda narratio, fida tamen, de commodis et incolarum '\
                                       'ritibus Virginæ ... America. pt. 1. Francoforti ad Moenum, 1590.',
@@ -406,7 +424,7 @@ describe MarcToArgot::Macros::Shared::Notes do
                           {'label' => 'Original version',
                            'value' => 'Faksimile-uitg. van de autografen, 1786, 1787.',
                            'indexed' => 'false'}
-                          ])
+                         ])
   end
 
   it '(MTA) sets note_scale from 507' do
@@ -431,25 +449,25 @@ describe MarcToArgot::Macros::Shared::Notes do
   it '(MTA) sets note_supplement' do
     result = note_supplement['note_supplement']
     expect(result).to eq(['Vols. for 196 - accompanied by separately paged supplement: Beteiligungen des '\
-      'Bundes im Haushaltsjahr ... , issued earlier as a section of the Finanzbericht.'])
+                          'Bundes im Haushaltsjahr ... , issued earlier as a section of the Finanzbericht.'])
   end
 
   it '(MTA) sets note_system_details' do
     result = note_system_details['note_system_details']
     expect(result).to eq(
-      ['v.1-2: Digital master conforms to: Benchmark for Faithful Digital Reproductions of Monographs '\
-        'and Serials. Version 1. Digital Library Federation, December 2002 '\
-        'http://www.diglib.org/standards/bmarkfin.htm',
-       'Videodisc: DVD; stereo. or 5.1 surround.'
-      ])
+                        ['v.1-2: Digital master conforms to: Benchmark for Faithful Digital Reproductions of Monographs '\
+                         'and Serials. Version 1. Digital Library Federation, December 2002 '\
+                         'http://www.diglib.org/standards/bmarkfin.htm',
+                         'Videodisc: DVD; stereo. or 5.1 surround.'
+                        ])
   end
 
   it '(MTA) sets note_with' do
     result = note_with['note_with']
     expect(result).to eq(
-      ['With: Chong kan Song ben Mengzi zhu shu, [Taibei Shi : Yi wen yin shu guan, Min guo 44 i.e. 1955]',
-       'With: 重栞宋本孟子注疏, [北市 : 藝文印書館, 民國44 i.e. 1955]']
-    )
+                        ['With: Chong kan Song ben Mengzi zhu shu, [Taibei Shi : Yi wen yin shu guan, Min guo 44 i.e. 1955]',
+                         'With: 重栞宋本孟子注疏, [北市 : 藝文印書館, 民國44 i.e. 1955]']
+                      )
   end
 
   xit '(MTA) sets note_system_details from vernacular' do
@@ -457,7 +475,7 @@ describe MarcToArgot::Macros::Shared::Notes do
     expect(result).to eq(
                         [ 'Xi tong yao qiu: Blu-ray bo fang she bei ji xiang guan ruan jian.',
                           '系统要求: Blu-ray播放设备及相关软件.'
-      ])
+                        ])
   end
 
 end

--- a/spec/macros/shared/publication_year_spec.rb
+++ b/spec/macros/shared/publication_year_spec.rb
@@ -1,6 +1,5 @@
 # coding: iso-8859-1
 require 'spec_helper'
-#require_relative '../../../lib/marc_to_argot/macros/shared/publication_year'
 include MarcToArgot::Macros::Shared::PublicationYear
 
 describe MarcToArgot do

--- a/spec/macros/unc/urls_spec.rb
+++ b/spec/macros/unc/urls_spec.rb
@@ -1,111 +1,269 @@
-# coding: utf-8
+# coding: iso-8859-1
 require 'spec_helper'
+include MarcToArgot::Macros::Shared::Helpers
+include MarcToArgot::Macros::UNC::Urls
 
 describe MarcToArgot::Macros::UNC::Urls do
   include Util
-  
-  let(:indexer) { MarcToArgot::Indexers::UNC.new }
-  let(:url_recs) { MARC::XMLReader.new(find_marc('unc', 'url_spec')).to_a }
-  let(:expected_text) {
-    [
-      #1
-      ['v. 1 -- Full text available via the UNC-Chapel Hill Libraries',
-       'v. 2 -- Full text available via the UNC-Chapel Hill Libraries',
-       'v. 3 -- Full text available via the UNC-Chapel Hill Libraries'],
-      #2
-      ['Bd.1 -- Available via the UNC-Chapel Hill Libraries',
-       'Bd.2 -- Available via the UNC-Chapel Hill Libraries'],
-      #3
-      ['Full text available via the UNC-Chapel Hill Libraries'],
-      #4
-      ['Available via the UNC-Chapel Hill Libraries'],
-      #5
-      ['Finding aid to the Archie Green archival collection'],
-      #6
-      ['More information about this item in: Russia Beyond Russia: The André Savine Digital Library'],
-      #7
-      ['Thumbnail image',
-       'DOWNLOAD DATA HERE'],
-      #8
-      nil,
-      #9
-      ['Table of contents only'],
-      #10
-      ['Available via the UNC-Chapel Hill Libraries'],
-      #11
-      nil,
-      #12
-      ['PDF version -- Available via the UNC-Chapel Hill Libraries'],
-    ]
-  }
 
-  let(:expected_type) {
-    [
-      #1
-      ['fulltext',
-       'fulltext',
-       'fulltext'],
-      #2
-      ['fulltext',
-       'fulltext'],
-      #3
-      ['fulltext'],
-      #4
-      ['fulltext'],
-      #5
-      ['findingaid'],
-      #6
-      ['related'],
-      #7
-      ['thumbnail',
-       'fulltext'],
-      #8
-      ['other'],
-      #9
-      ['other'],
-      #10
-      ['fulltext'],
-      #11
-      nil,
-      #12
-      ['fulltext']
-    ]
-  }
-  
-  it 'extracts link text' do
-    indexer.instance_eval do
-      each_record do |rec, cxt|
-        url(rec, cxt)
+  def make_rec
+    rec = MARC::Record.new
+    rec << MARC::ControlField.new('008', ' ' * 40)
+    return rec
+  end
+
+  def return_argot_url_field(rec)
+    argot = run_traject_on_record('unc', rec)
+    url_field = argot['url']
+    url_field = url_field.map{ |u| JSON.parse(u) } if url_field
+  end
+
+  describe 'url' do
+    context 'when $u is repeated in a given 856' do
+      it '(UNC) extracts only the first $u' do
+        rec = make_rec
+        rec << MARC::DataField.new('856', '4', '0', ['u', 'http://this.org'], ['u', 'http://that.org'])
+        url = return_argot_url_field(rec)
+        expect(url[0]['href']).to eq('http://this.org')
+        expect(url.size).to eq(1)
       end
     end
-    url_recs.each_with_index do |rec, idx|
-      exp = expected_text[idx]
-      unless exp.nil?
-        argotout = indexer.map_record(rec)
-        urlfield = argotout['url']
-        output = urlfield.map { |u| JSON.parse(u)['text'] } #unless urlfield.empty?
-        expect(output.length).to eq(exp.length), "Record #{idx +1} in error\nExpected:\n#{exp}\nOutput:\n #{output}"
-        expect(output).to eq(exp)
+
+    context 'when there is NO $u in 856' do
+      it '(UNC) no url element output' do
+        rec = make_rec
+        rec << MARC::DataField.new('856', '4', '0', ['z', 'http://this.org'], ['y', 'http://that.org'])
+        url = return_argot_url_field(rec)
+        expect(url).to be_nil
+      end
+    end
+
+    context 'when 856 field is repeated in record' do
+      it '(UNC) output multiple url field elements' do
+        rec = make_rec
+        rec << MARC::DataField.new('856', '4', '0', ['u', 'http://this.org'])
+        rec << MARC::DataField.new('856', '4', '0', ['u', 'http://that.org'])
+        url = return_argot_url_field(rec)
+        expect(url.size).to eq(2)
+      end
+    end
+
+    context 'when there is no 856 field in record' do
+      it '(UNC) no url field output' do
+        rec = make_rec
+        url = return_argot_url_field(rec)
+        expect(url).to be_nil
+      end
+    end
+
+    it '(UNC) writes url[type]' do
+      rec = make_rec
+      rec << MARC::DataField.new('856', '4', '0', ['u', 'http://this.org'])
+      rec << MARC::DataField.new('856', '4', '2', ['u', 'http://that.io'], ['3', 'Thumbnail'])
+      url = return_argot_url_field(rec)
+      expect(url[0]['type']).to eq('fulltext')
+      expect(url[1]['type']).to eq('thumbnail')
+    end
+
+    it '(UNC) writes url[text] appropriately given shared record status' do
+      rec = make_rec
+      rec << MARC::DataField.new('856', '4', '0', ['u', 'http://that.io'], ['3', 'In Spanish'])
+      url = return_argot_url_field(rec)
+      expect(url[0]['text']).to eq('In Spanish -- Available via the UNC-Chapel Hill Libraries')
+
+      rec2 = make_rec
+      rec2 << MARC::DataField.new('856', '4', '0', ['u', 'http://that.io'], ['3', 'In Spanish'])
+      rec2 << MARC::DataField.new('919', ' ', ' ', ['a', 'aspanth'])
+      url2 = return_argot_url_field(rec2)
+      expect(url2[0]['text']).to eq('In Spanish')
+    end
+
+    context 'when url is for a restricted resource' do
+      it '(UNC) does NOT write out url[restricted] (because the default value is true)' do
+        rec = make_rec
+        rec << MARC::DataField.new('856', '4', '0', ['u', 'http://unc.kanopystreaming.com/134'])
+        url = return_argot_url_field(rec)
+        expect(url[0]['restricted']).to be_nil
+      end
+    end
+    context 'when url is for an unrestricted resource' do
+      it '(UNC) writes out url[restricted] = false' do
+        rec = make_rec
+        rec << MARC::DataField.new('856', '4', '0', ['u', 'http://that.io'])
+        url = return_argot_url_field(rec)
+        expect(url[0]['restricted']).to eq('false')
       end
     end
   end
 
-  it 'extracts link type' do
-    indexer.instance_eval do
-      each_record do |rec, cxt|
-        url(rec, cxt)
+  describe 'normal_url_text' do
+    context 'when $y present and no $3 present' do
+      it '(UNC) sets url[text] from $y' do
+        field = MARC::DataField.new('856', '4', '0', ['u', 'uri'], ['y', 'text'])
+        v = normal_url_text(field)
+        expect(v).to eq('text')
       end
     end
-    url_recs.each_with_index do |rec, idx|
-      exp = expected_type[idx]
-      unless exp.nil?
-        argotout = indexer.map_record(rec)
-        urlfield = argotout['url']
-        output = urlfield.map { |u| JSON.parse(u)['type'] } #unless urlfield.empty?
-        expect(output.length).to eq(exp.length), "Record #{idx +1} in error\nExpected:\n#{exp}\nOutput:\n #{output}"
-        expect(output).to eq(exp)
+    context 'when $3 present and no $y present' do
+      it '(UNC) sets url[text] from $3 and constant value, in that order, separated by \' -- \'' do
+        field = MARC::DataField.new('856', '4', '0', ['u', 'uri'], ['3', 'label'])
+        v = normal_url_text(field)
+        expect(v).to eq('label -- Available via the UNC-Chapel Hill Libraries')
+      end
+    end
+    context 'when $3 present and $y present' do
+      it '(UNC) sets url[text] from $3 and $y, in that order, separated by \' -- \'' do
+        rec = make_rec
+        field = MARC::DataField.new('856', '4', '0', ['u', 'uri'], ['y', 'text'], ['3', 'label'])
+        v = normal_url_text(field)
+        expect(v).to eq('label -- text')
+      end
+    end
+    context 'when NO $3 present and NO $y present' do
+      it '(UNC) provides constant url[text]' do
+        field = MARC::DataField.new('856', '4', '0', ['u', 'uri'])
+        v = normal_url_text(field)
+        expect(v).to eq('Available via the UNC-Chapel Hill Libraries')
       end
     end
   end
 
+  describe 'shared_record_url_text' do
+    context 'when $y present and no $3 present' do
+      it '(UNC) does NOT set url[text] from $y' do
+        field = MARC::DataField.new('856', '4', '0', ['u', 'uri'], ['y', 'text'])
+        v = shared_record_url_text(field)
+        expect(v).to be_nil
+      end
+    end
+    context 'when $3 present and no $y present' do
+      it '(UNC) sets url[text] from $3' do
+        field = MARC::DataField.new('856', '4', '0', ['u', 'uri'], ['3', 'label'])
+        v = shared_record_url_text(field)
+        expect(v).to eq('label')
+      end
+    end
+    context 'when $3 present and $y present' do
+      it '(UNC) sets url[text] from $3' do
+        field = MARC::DataField.new('856', '4', '0', ['u', 'uri'], ['y', 'text'], ['3', 'label'])
+        v = shared_record_url_text(field)
+        expect(v).to eq('label')
+      end
+    end
+    context 'when NO $3 present and NO $y present' do
+      it '(UNC) does NOT set url[text]' do
+        field = MARC::DataField.new('856', '4', '0', ['u', 'uri'])
+        v = shared_record_url_text(field)
+        expect(v).to be_nil
+      end
+    end
+  end
+
+  describe 'url_type_value (this code lives in the shared URLs macro)' do
+    context 'when i2 = 0' do
+      it '(MTA) url[type] = fulltext' do
+        field = MARC::DataField.new('856', '4', '0', ['u', 'uri'])
+        v = url_type_value(field)
+        expect(v).to eq('fulltext')
+      end
+    end
+    context 'when i2 = 1' do
+      it '(MTA) url[type] = fulltext' do
+        field = MARC::DataField.new('856', '4', '1', ['u', 'uri'])
+        v = url_type_value(field)
+        expect(v).to eq('fulltext')
+      end
+    end
+    context 'when i2 = 2 and $3 contains thumbnail' do
+      it '(MTA) url[type] = thumbnail' do
+        field = MARC::DataField.new('856', '4', '2', ['u', 'uri'], ['3', 'Thumbnail image'])
+        v = url_type_value(field)
+        expect(v).to eq('thumbnail')
+      end
+    end
+    context 'when i2 = 2 and $3 contains finding aid' do
+      it '(MTA) url[type] = findingaid' do
+        field = MARC::DataField.new('856', '4', '2', ['u', 'uri'], ['3', 'Finding aid:'])
+        v = url_type_value(field)
+        expect(v).to eq('findingaid')
+      end
+    end
+    context 'when i2 = 2 and no special $3 value present' do
+      it '(MTA) url[type] = related' do
+        field = MARC::DataField.new('856', '4', '2', ['u', 'uri'], ['3', 'Errata'])
+        v = url_type_value(field)
+        expect(v).to eq('related')
+      end
+    end
+    context 'when i2 = 8' do
+      it '(MTA) url[type] = other' do
+        field = MARC::DataField.new('856', '4', '8', ['u', 'uri'], ['3', 'Errata'])
+        v = url_type_value(field)
+        expect(v).to eq('other')
+      end
+    end
+    context 'when i2 = blank' do
+      it '(MTA) url[type] = other' do
+        field = MARC::DataField.new('856', '4', ' ', ['u', 'uri'], ['3', 'Errata'])
+        v = url_type_value(field)
+        expect(v).to eq('other')
+      end
+    end
+  end
+
+  describe 'is_proxied?' do
+    context 'URL begins with http://libproxy.lib.unc.edu/login?url=' do
+      it '(UNC) returns true' do
+        url = 'http://libproxy.lib.unc.edu/login?url=https://blahblah'
+        v = is_proxied?(url)
+        expect(v).to eq(true)
+      end
+    end
+    context 'URL does not begin with http://libproxy.lib.unc.edu/login?url=' do
+      it '(UNC) returns nil value' do
+        url = 'https://blahblah'
+        v = is_proxied?(url)
+        expect(v).to eq(false)
+      end
+    end
+  end
+
+  describe 'is_restricted?' do
+    context 'URL is proxied' do
+      it '(UNC) returns true' do
+        url = 'http://libproxy.lib.unc.edu/login?url=https://blahblah'
+        v = is_restricted?(url)
+        expect(v).to eq(true)
+      end
+    end
+    context 'URL begins with http://unc.kanopystreaming.com' do
+      it '(UNC) returns true' do
+        url = 'http://unc.kanopystreaming.com/blahblah'
+        v = is_restricted?(url)
+        expect(v).to eq(true)
+      end
+    end
+    context 'URL begins with http://vb3lk7eb4t.search.serialssolutions.com' do
+      it '(UNC) returns true' do
+        url = 'http://vb3lk7eb4t.search.serialssolutions.com/blahblah'
+        v = is_restricted?(url)
+        expect(v).to eq(true)
+      end
+    end
+    context 'URL does NOT begin with restricted URL string' do
+      it '(UNC) returns nil value' do
+        url = 'https://purl.fdlp.gov/GPO/gpo92270'
+        v = is_restricted?(url)
+        expect(v).to eq(false)
+      end
+    end
+  end
+
+  describe 'template_proxy' do
+    it '(UNC) returns url with proxy prefix as a URL template parameter' do
+      url = 'http://libproxy.lib.unc.edu/login?url=https://blahblah'
+      v = template_proxy(url)
+      expect(v).to eq('{proxyPrefix}https://blahblah')
+    end
+  end
 end


### PR DESCRIPTION
* Outputs note_cited_in so that it can be processed as an indexed note field
* UNC-only refactoring of URL-related processing
* removal of unneeded commented out stuff in publication_year macro

Draft release: https://github.com/trln/marc-to-argot/releases/edit/untagged-f36072a34c595b0f3676