### PR TITLE
653 w i2=4 mapped to subject_topical instead of subject_chronological

### DIFF
--- a/lib/marc_to_argot/macros/shared/subject_genre.rb
+++ b/lib/marc_to_argot/macros/shared/subject_genre.rb
@@ -95,6 +95,7 @@ module MarcToArgot
                    '650abcdgx:'\
                    '651x:653|*0|a:653|*1|a:653|*2|a:'\
                    '653|*3|a:'\
+                   '653|*4|a:'\
                    '656ax:'\
                    '657ax'
             Traject::MarcExtractor.cached(spec).each_matching_line(rec) do |field, spec|
@@ -114,7 +115,7 @@ module MarcToArgot
         def subject_chronological
           lambda do |rec, acc|
             spec = '600y:610y:611y:630y:'\
-                   '648a:650y:651y:653|*4|a:'\
+                   '648a:650y:651y:'\
                    '655y:656y:657y'
             Traject::MarcExtractor.cached(spec).each_matching_line(rec) do |field, spec|
 

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.2.10'.freeze
+  VERSION = '0.2.11'.freeze
 end

--- a/spec/mta_subject_genre_spec.rb
+++ b/spec/mta_subject_genre_spec.rb
@@ -265,6 +265,17 @@ describe MarcToArgot do
                         )
     end
 
+    it '(MTA) sets subject_topical from 653 with 2nd ind = 4 (instead of subject_chronological)' do
+      rec = make_rec
+      rec << MARC::DataField.new('653', '0', '4', ['a', 'Sloppy data'])
+      rec << MARC::DataField.new('650', '0', '0', ['a', 'Invalid cataloging'], ['y', '21st century'])
+      argot = run_traject_on_record('unc', rec)
+      result_top = argot['subject_topical']
+      result_chron = argot['subject_chronological']
+      expect(result_top).to include('Sloppy data')
+      expect(result_chron).to eq(['21st century'])
+    end
+
     it '(MTA) sets separate genre headings values from 382 subfields' do
       result = genre6['genre_headings']
       expect(result).to include(


### PR DESCRIPTION
* map 653 with i2=4 to `subject_topical` facet instead of `subject_chronological` facet

Draft release: https://github.com/trln/marc-to-argot/releases/edit/untagged-43181f7e682e3d6019b9