### PR TITLE
Add Duke bookplate data to notes. Fix cataloged date edge case.

### DIFF
--- a/lib/data/argot/traject_config.rb
+++ b/lib/data/argot/traject_config.rb
@@ -96,7 +96,7 @@ end
 
 unless settings['override'].include?('date_cataloged')
   to_field 'date_cataloged' do |rec, acc|
-    cataloged = Traject::MarcExtractor.cached(settings['specs'][:date_cataloged]).extract(rec).first
+    cataloged = Traject::MarcExtractor.cached(settings['specs'][:date_cataloged]).extract(rec).first.to_s.strip
     begin
       acc << Time.parse(cataloged).utc.iso8601 if cataloged =~ /\A?[0-9]*\.?[0-9]+\Z/
     rescue ArgumentError => e

--- a/lib/data/duke/traject_config.rb
+++ b/lib/data/duke/traject_config.rb
@@ -44,6 +44,12 @@ to_field 'institution', literal('duke')
 #########
 to_field 'names', names
 
+##################
+# Bookplate
+#########
+to_field 'bookplate', extract_marc("796z")
+
+
 ################################################
 # Items
 ######
@@ -336,5 +342,6 @@ end
 
 each_record do |rec, ctx|
   remove_print_from_archival_material(ctx)
+  add_bookplate_to_notes_local(ctx)
   Logging.mdc.clear
 end

--- a/lib/marc_to_argot/macros/duke_macros.rb
+++ b/lib/marc_to_argot/macros/duke_macros.rb
@@ -33,7 +33,10 @@ module MarcToArgot
       # @param field [MARC::DataField] the field to check for a finding aid URL
       def url_for_finding_aid?(field)
         substring_present_in_subfield?(field, 'u', 'library.duke.edu/rubenstein/findingaids') ||
-          substring_present_in_subfield?(field, 'y', 'collection guide')
+          substring_present_in_subfield?(field, 'y', 'collection guide') ||
+          substring_present_in_subfield?(field, '3', 'collection guide') ||
+          substring_present_in_subfield?(field, 'y', 'finding aid') ||
+          substring_present_in_subfield?(field, '3', 'finding aid')
       end
 
       # OCLC Number & Rollup ID
@@ -95,6 +98,15 @@ module MarcToArgot
         def ebook_location_codes
           %w[DKK FRDK1 FRDK2 FRDK3 PDK PKKI PKKR PKKZ
              PKXKR PLK1 PLK2 PLKR PLXKR PZK1 PZK2]
+        end
+      end
+
+      def add_bookplate_to_notes_local(ctx)
+        if ctx.output_hash.key?('bookplate')
+          bookplate = ctx.output_hash['bookplate'].map { |bp| { 'value' => bp } }
+          local_notes = ctx.output_hash.fetch('note_local', [])
+          ctx.output_hash['note_local'] = local_notes.concat(bookplate)
+          ctx.output_hash.delete('bookplate')
         end
       end
 

--- a/lib/marc_to_argot/macros/shared/names.rb
+++ b/lib/marc_to_argot/macros/shared/names.rb
@@ -17,6 +17,7 @@ module MarcToArgot
               names = assemble_names_hash(field)
 
               acc << names unless names.empty?
+              acc.uniq!
               Logging.mdc.delete('field')
             end
           end

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.2.13'.freeze
+  VERSION = '0.2.14'.freeze
 end


### PR DESCRIPTION
* Handle Duke bookplate data -- add it to notes for now.
* Call uniq on names to remove duplicate entries.
* Strip spaces from date field before parsing.
* Deal with all the various ways we encode finding aid links.