### PR TITLE
ncsu local change to separate multiple url notes with a semicolon.

### DIFF
--- a/lib/marc_to_argot/macros/ncsu_macros.rb
+++ b/lib/marc_to_argot/macros/ncsu_macros.rb
@@ -76,7 +76,7 @@ module MarcToArgot
       def url_note(field)
         subfield_values = collect_subfield_values_by_code(field, '3')
         subfield_values += collect_subfield_values_by_code(field, 'z')
-        [subfield_values.join('; ')].reject(&:empty?).join('; ')
+        subfield_values.reject(&:empty?).join('; ')
       end
 
       def open_access!(urls, items)

--- a/lib/marc_to_argot/macros/ncsu_macros.rb
+++ b/lib/marc_to_argot/macros/ncsu_macros.rb
@@ -76,7 +76,7 @@ module MarcToArgot
       def url_note(field)
         subfield_values = collect_subfield_values_by_code(field, '3')
         subfield_values += collect_subfield_values_by_code(field, 'z')
-        [subfield_values.join(' ')].reject(&:empty?).join(' ')
+        [subfield_values.join('; ')].reject(&:empty?).join('; ')
       end
 
       def open_access!(urls, items)

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.3.2'.freeze
 end

--- a/spec/data/ncsu/empty-856-notes.xml
+++ b/spec/data/ncsu/empty-856-notes.xml
@@ -1,0 +1,116 @@
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+<record>
+  <leader>02299nam a2200397 i 4500</leader>
+  <controlfield tag="001">SMIT000385</controlfield>
+  <controlfield tag="003">MiFhGG</controlfield>
+  <controlfield tag="005">20150214201936.0</controlfield>
+  <controlfield tag="006">m    |   d |      </controlfield>
+  <controlfield tag="007">cr |n||||||||n</controlfield>
+  <controlfield tag="008">980529s1897    be      o     100 0 fre d</controlfield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(Sirsi) SMIT000385</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)904657474</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">MIGCL</subfield>
+    <subfield code="b">eng</subfield>
+    <subfield code="c">UtOrBLW</subfield>
+    <subfield code="e">rda</subfield>
+  </datafield>
+  <datafield tag="111" ind1="2" ind2=" ">
+    <subfield code="a">Congrès international colonial</subfield>
+    <subfield code="d">(1897 :</subfield>
+    <subfield code="c">Brussels, Belgium)</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Congrès international colonial :</subfield>
+    <subfield code="b">sous le haut patronage de S.M. le Roi des Belges ... /</subfield>
+    <subfield code="c">pour la Commission d&apos;Organisation, le Commissaire du Gouvernement prés la XIVe section, Léon Janssen ; le Président de la XIVe section, Baron Lambert.</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Brux[elles] :</subfield>
+    <subfield code="b">Imp. des Travaux publics,</subfield>
+    <subfield code="c">[1897?]</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">1 online resource (4 unnumbered pages).</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">computer</subfield>
+    <subfield code="b">c</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">online resource</subfield>
+    <subfield code="b">cr</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="490" ind1="1" ind2=" ">
+    <subfield code="a">Smithsonian collections online : world&apos;s fairs and expositions : visions of tomorrow</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Caption title.</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">At head of title: Exposition internationale de Bruxelles 1897, XIVe section.</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Reproduction of the original from the Smithsonian Libraries.</subfield>
+  </datafield>
+  <datafield tag="520" ind1=" " ind2=" ">
+    <subfield code="a">An invitation to attend the Congrès international colonial, which will be held on Aug. 16-19, 1897, in Brussels.</subfield>
+  </datafield>
+  <datafield tag="596" ind1=" " ind2=" ">
+    <subfield code="a">8</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Colonies</subfield>
+    <subfield code="v">Congresses.</subfield>
+  </datafield>
+  <datafield tag="711" ind1="2" ind2=" ">
+    <subfield code="a">Exposition internationale Bruxelles-Tervueren</subfield>
+    <subfield code="d">(1897),</subfield>
+    <subfield code="j">host institution.</subfield>
+  </datafield>
+  <datafield tag="773" ind1=" " ind2=" ">
+    <subfield code="a">Gale Cengage Learning, Smithsonian Collections Online</subfield>
+  </datafield>
+  <datafield tag="830" ind1=" " ind2="0">
+    <subfield code="a">Smithsonian collections online : world&apos;s fairs and expositions : visions of tomorrow.</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="0">
+    <subfield code="3"></subfield>
+    <subfield code="u">https://proxying.lib.ncsu.edu/index.php?url=http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&amp;url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&amp;res_id=info:sid/gale:SMIT&amp;ctx_enc=info:ofi:enc:UTF-8&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:unknown&amp;rft.artnum=BIBJUB047717205&amp;req_dat=info:sid/gale:ugnid:ncsu_main</subfield>
+    <subfield code="z"></subfield>
+    <subfield code="y">View resource online (NCSU only)</subfield>
+  </datafield>
+  <datafield tag="909" ind1=" " ind2=" ">
+    <subfield code="a">20180814</subfield>
+  </datafield>
+  <datafield tag="918" ind1=" " ind2=" ">
+    <subfield code="a">4411038</subfield>
+  </datafield>
+  <datafield tag="949" ind1=" " ind2=" ">
+    <subfield code="h">ONLINEBOOK</subfield>
+  </datafield>
+  <datafield tag="999" ind1=" " ind2=" ">
+    <subfield code="a">XX(4411038.1)</subfield>
+    <subfield code="w">AUTO</subfield>
+    <subfield code="c">1</subfield>
+    <subfield code="i">4411038-1001</subfield>
+    <subfield code="l">NET</subfield>
+    <subfield code="m">ONLINE</subfield>
+    <subfield code="r">Y</subfield>
+    <subfield code="s">Y</subfield>
+    <subfield code="t">EBOOK</subfield>
+    <subfield code="u">8/14/2018</subfield>
+  </datafield>
+</record>
+</collection>

--- a/spec/data/ncsu/multiple-856-notes.xml
+++ b/spec/data/ncsu/multiple-856-notes.xml
@@ -1,0 +1,116 @@
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+<record>
+  <leader>02299nam a2200397 i 4500</leader>
+  <controlfield tag="001">SMIT000385</controlfield>
+  <controlfield tag="003">MiFhGG</controlfield>
+  <controlfield tag="005">20150214201936.0</controlfield>
+  <controlfield tag="006">m    |   d |      </controlfield>
+  <controlfield tag="007">cr |n||||||||n</controlfield>
+  <controlfield tag="008">980529s1897    be      o     100 0 fre d</controlfield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(Sirsi) SMIT000385</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)904657474</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">MIGCL</subfield>
+    <subfield code="b">eng</subfield>
+    <subfield code="c">UtOrBLW</subfield>
+    <subfield code="e">rda</subfield>
+  </datafield>
+  <datafield tag="111" ind1="2" ind2=" ">
+    <subfield code="a">Congrès international colonial</subfield>
+    <subfield code="d">(1897 :</subfield>
+    <subfield code="c">Brussels, Belgium)</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Congrès international colonial :</subfield>
+    <subfield code="b">sous le haut patronage de S.M. le Roi des Belges ... /</subfield>
+    <subfield code="c">pour la Commission d&apos;Organisation, le Commissaire du Gouvernement prés la XIVe section, Léon Janssen ; le Président de la XIVe section, Baron Lambert.</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Brux[elles] :</subfield>
+    <subfield code="b">Imp. des Travaux publics,</subfield>
+    <subfield code="c">[1897?]</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">1 online resource (4 unnumbered pages).</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">computer</subfield>
+    <subfield code="b">c</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">online resource</subfield>
+    <subfield code="b">cr</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="490" ind1="1" ind2=" ">
+    <subfield code="a">Smithsonian collections online : world&apos;s fairs and expositions : visions of tomorrow</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Caption title.</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">At head of title: Exposition internationale de Bruxelles 1897, XIVe section.</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Reproduction of the original from the Smithsonian Libraries.</subfield>
+  </datafield>
+  <datafield tag="520" ind1=" " ind2=" ">
+    <subfield code="a">An invitation to attend the Congrès international colonial, which will be held on Aug. 16-19, 1897, in Brussels.</subfield>
+  </datafield>
+  <datafield tag="596" ind1=" " ind2=" ">
+    <subfield code="a">8</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Colonies</subfield>
+    <subfield code="v">Congresses.</subfield>
+  </datafield>
+  <datafield tag="711" ind1="2" ind2=" ">
+    <subfield code="a">Exposition internationale Bruxelles-Tervueren</subfield>
+    <subfield code="d">(1897),</subfield>
+    <subfield code="j">host institution.</subfield>
+  </datafield>
+  <datafield tag="773" ind1=" " ind2=" ">
+    <subfield code="a">Gale Cengage Learning, Smithsonian Collections Online</subfield>
+  </datafield>
+  <datafield tag="830" ind1=" " ind2="0">
+    <subfield code="a">Smithsonian collections online : world&apos;s fairs and expositions : visions of tomorrow.</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="0">
+    <subfield code="3">Gale Cengage Learning, Smithsonian Collections Online: World&apos;s Fairs and Expositions: Visions of Tomorrow</subfield>
+    <subfield code="u">https://proxying.lib.ncsu.edu/index.php?url=http://find.galegroup.com/openurl/openurl?url_ver=Z39.88-2004&amp;url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&amp;res_id=info:sid/gale:SMIT&amp;ctx_enc=info:ofi:enc:UTF-8&amp;rft_val_fmt=info:ofi/fmt:kev:mtx:unknown&amp;rft.artnum=BIBJUB047717205&amp;req_dat=info:sid/gale:ugnid:ncsu_main</subfield>
+    <subfield code="z">Gale Cengage Learning</subfield>
+    <subfield code="y">View resource online (NCSU only)</subfield>
+  </datafield>
+  <datafield tag="909" ind1=" " ind2=" ">
+    <subfield code="a">20180814</subfield>
+  </datafield>
+  <datafield tag="918" ind1=" " ind2=" ">
+    <subfield code="a">4411038</subfield>
+  </datafield>
+  <datafield tag="949" ind1=" " ind2=" ">
+    <subfield code="h">ONLINEBOOK</subfield>
+  </datafield>
+  <datafield tag="999" ind1=" " ind2=" ">
+    <subfield code="a">XX(4411038.1)</subfield>
+    <subfield code="w">AUTO</subfield>
+    <subfield code="c">1</subfield>
+    <subfield code="i">4411038-1001</subfield>
+    <subfield code="l">NET</subfield>
+    <subfield code="m">ONLINE</subfield>
+    <subfield code="r">Y</subfield>
+    <subfield code="s">Y</subfield>
+    <subfield code="t">EBOOK</subfield>
+    <subfield code="u">8/14/2018</subfield>
+  </datafield>
+</record>
+</collection>

--- a/spec/macros/ncsu/urls_spec.rb
+++ b/spec/macros/ncsu/urls_spec.rb
@@ -10,6 +10,7 @@ describe MarcToArgot::Macros do
   let(:ejournal) { run_traject_json('ncsu', 'ejournal') }
   let(:url_note_record) { run_traject_json('ncsu', 'audiobook') }
   let(:multiple_url_note_record) { run_traject_json('ncsu', 'multiple-856-notes') }
+  let(:empty_url_note_record) { run_traject_json('ncsu', 'empty-856-notes') }
 
   context 'NCSU' do
     it 'outputs restricted=false if there is an 856 and online and open access' do
@@ -35,6 +36,11 @@ describe MarcToArgot::Macros do
     it 'should concatenate multiple 856$3$z fields to url note' do
       url = multiple_url_note_record['url'].map { |u| JSON.parse(u) }.first
       expect(url['note']).to eq("Gale Cengage Learning, Smithsonian Collections Online: World's Fairs and Expositions: Visions of Tomorrow; Gale Cengage Learning")
+    end
+
+    it 'should not output url["note"] when 856$3$z are empty' do
+      url = empty_url_note_record['url'].map { |u| JSON.parse(u) }.first
+      expect(url['note']).to be_nil
     end
   end
 end

--- a/spec/macros/ncsu/urls_spec.rb
+++ b/spec/macros/ncsu/urls_spec.rb
@@ -9,6 +9,7 @@ describe MarcToArgot::Macros do
   let(:open_access_record) { run_traject_json('ncsu', 'open_access_ejournal') }
   let(:ejournal) { run_traject_json('ncsu', 'ejournal') }
   let(:url_note_record) { run_traject_json('ncsu', 'audiobook') }
+  let(:multiple_url_note_record) { run_traject_json('ncsu', 'multiple-856-notes') }
 
   context 'NCSU' do
     it 'outputs restricted=false if there is an 856 and online and open access' do
@@ -29,6 +30,11 @@ describe MarcToArgot::Macros do
     it 'should output url note from the 856$z field' do
       url = url_note_record['url'].map { |u| JSON.parse(u) }.first
       expect(url['note']).to eq('Available to participating NC libraries through NC LIVE.')
+    end
+
+    it 'should concatenate multiple 856$3$z fields to url note' do
+      url = multiple_url_note_record['url'].map { |u| JSON.parse(u) }.first
+      expect(url['note']).to eq("Gale Cengage Learning, Smithsonian Collections Online: World's Fairs and Expositions: Visions of Tomorrow; Gale Cengage Learning")
     end
   end
 end


### PR DESCRIPTION
 - concatenates multiple 856$3$z notes with a `join('; ') ` instead of `join(' ')`.