### PR TITLE
fix exit status on mta script

### DIFF
--- a/exe/mta
+++ b/exe/mta
@@ -8,6 +8,3 @@ $LOAD_PATH << self_load_path unless $LOAD_PATH.include? self_load_path
 require 'marc_to_argot'
 
 result = MarcToArgot::CommandLine.start(ARGV)
-
-# non-zero exit status on process telling us there's problems.
-exit 1 unless result

--- a/lib/marc_to_argot/command_line.rb
+++ b/lib/marc_to_argot/command_line.rb
@@ -120,6 +120,7 @@ module MarcToArgot
         rescue StandardError => e
           puts "OH NO YOU DI'INT"
           log.fatal e.message
+          exit 4
         end
       end
 

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.4.1'.freeze
+  VERSION = '0.4.2'.freeze
 end


### PR DESCRIPTION
mta script would always return 1 as the exit status on a successful run.  No longer.