### PR TITLE
emit creator_main field

### DIFF
--- a/lib/data/argot/traject_config.rb
+++ b/lib/data/argot/traject_config.rb
@@ -149,6 +149,10 @@ unless settings["override"].include?("names")
   to_field "names", names
 end
 
+unless settings['override'].include?('creator_main')
+  to_field 'creator_main', creator_main
+end
+
 ################################################
 # Title
 ######

--- a/lib/marc_to_argot/macros/shared/creator_main.rb
+++ b/lib/marc_to_argot/macros/shared/creator_main.rb
@@ -1,17 +1,11 @@
-# coding: utf-8
-
-require_relative './names'
-
 module MarcToArgot
   module Macros
     module Shared
       module CreatorMain
-        include MarcToArgot::Macros::Shared::Names
-        
         def creator_main
           lambda do |rec, acc|
             creators = []
-            
+
             Traject::MarcExtractor.cached('100:110:111')
                                   .each_matching_line(rec) do |field, spec, extractor|
 
@@ -31,10 +25,9 @@ module MarcToArgot
           if rel_part.length > 0
             name_part << ', ' unless name_part.end_with?('-')
           end
-          
+
           name_part + rel_part.join(', ')
         end
-        
       end
     end
   end

--- a/lib/marc_to_argot/macros/shared/creator_main.rb
+++ b/lib/marc_to_argot/macros/shared/creator_main.rb
@@ -1,0 +1,41 @@
+# coding: utf-8
+
+require_relative './names'
+
+module MarcToArgot
+  module Macros
+    module Shared
+      module CreatorMain
+        include MarcToArgot::Macros::Shared::Names
+        
+        def creator_main
+          lambda do |rec, acc|
+            creators = []
+            
+            Traject::MarcExtractor.cached('100:110:111')
+                                  .each_matching_line(rec) do |field, spec, extractor|
+
+              next unless subfield_5_absent_or_present_with_local_code?(field)
+              creators << get_creator(field)
+            end
+            acc << creators.reverse.join(' / ')
+            acc.compact!
+            acc.reject! { |e| e == '' }
+          end
+        end
+
+        def get_creator(field)
+          name_part = names_name(field)
+          rel_part = names_rel(field)
+
+          if rel_part.length > 0
+            name_part << ', ' unless name_part.end_with?('-')
+          end
+          
+          name_part + rel_part.join(', ')
+        end
+        
+      end
+    end
+  end
+end

--- a/lib/marc_to_argot/macros/shared/statement_of_responsibility.rb
+++ b/lib/marc_to_argot/macros/shared/statement_of_responsibility.rb
@@ -5,7 +5,6 @@ module MarcToArgot
         def statement_of_responsibility
           lambda do |rec, acc|
             sor = get_sor_from_245(rec, :alternate_script => true)
-            sor = get_sor_from_1xx(rec, :alternate_script => true) if sor.nil? || sor.empty?
             sor.each { |s| acc << s } unless sor.nil? || sor.empty?
             acc.uniq!
           end
@@ -23,20 +22,6 @@ module MarcToArgot
           end
           return sors unless sors.empty?
         end
-
-        def get_sor_from_1xx(rec, options)
-          sors = []
-          Traject::MarcExtractor.cached('100:110:111').each_matching_line(rec) do |field, spec, extractor|
-            value = names_name(field)
-            lang = Vernacular::ScriptClassifier.new(field, value).classify
-            sor = {}
-            sor['value'] = value unless value.nil? || value.empty?
-            sor['lang'] = lang unless lang.nil? || lang.empty?
-            sors << sor if sor.has_key?('value')
-          end
-          return sors unless sors.empty?
-        end
-        
       end
     end
   end

--- a/lib/marc_to_argot/macros/shared_macros.rb
+++ b/lib/marc_to_argot/macros/shared_macros.rb
@@ -1,11 +1,11 @@
-require 'marc_to_argot/macros/shared/call_numbers'
-require 'marc_to_argot/macros/shared/creator_main'
-require 'marc_to_argot/macros/shared/edition'
 require 'marc_to_argot/macros/shared/helpers'
+require 'marc_to_argot/macros/shared/call_numbers'
+require 'marc_to_argot/macros/shared/edition'
 require 'marc_to_argot/macros/shared/imprint'
 require 'marc_to_argot/macros/shared/language'
 require 'marc_to_argot/macros/shared/misc_id'
 require 'marc_to_argot/macros/shared/names'
+require 'marc_to_argot/macros/shared/creator_main'
 require 'marc_to_argot/macros/shared/notes'
 require 'marc_to_argot/macros/shared/physical_description'
 require 'marc_to_argot/macros/shared/physical_media'
@@ -30,14 +30,14 @@ module MarcToArgot
     # defined here, and overriden in institution-specific modules in the
     # same namespace.
     module Shared
-      include CallNumbers
-      include CreatorMain
-      include Edition
       include Helpers
+      include CallNumbers
+      include Edition
       include Imprint
       include Language
       include MiscId
       include Names
+      include CreatorMain
       include Notes
       include PhysicalDescription
       include PublicationYear

--- a/lib/marc_to_argot/macros/shared_macros.rb
+++ b/lib/marc_to_argot/macros/shared_macros.rb
@@ -1,4 +1,5 @@
 require 'marc_to_argot/macros/shared/call_numbers'
+require 'marc_to_argot/macros/shared/creator_main'
 require 'marc_to_argot/macros/shared/edition'
 require 'marc_to_argot/macros/shared/helpers'
 require 'marc_to_argot/macros/shared/imprint'
@@ -30,6 +31,7 @@ module MarcToArgot
     # same namespace.
     module Shared
       include CallNumbers
+      include CreatorMain
       include Edition
       include Helpers
       include Imprint

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.4.19'.freeze
+  VERSION = '0.4.20'.freeze
 end

--- a/spec/macros/shared/creator_main_spec.rb
+++ b/spec/macros/shared/creator_main_spec.rb
@@ -1,0 +1,50 @@
+# coding: utf-8
+require 'spec_helper'
+describe MarcToArgot::Macros::Shared::CreatorMain do
+  include Util::TrajectRunTest
+  
+  context 'record has 100 field' do
+    it '(MTA) sets creator_main from 100' do
+      rec = make_rec
+      rec << MARC::DataField.new('100', ' ', '1', ['a', 'Doe, Jane,'], ['d', '1970-'])
+      rt = run_traject_on_record('unc', rec)['creator_main']
+      expect(rt).to eq(['Doe, Jane, 1970-'])
+    end
+
+    context '100 has redundant $e and $4' do
+      it '(MTA) uses names macro relator handling logic to deduplicate' do
+        rec = make_rec
+        rec << MARC::DataField.new('100', ' ', '1', ['a', 'Doe, Jane,'],
+                                   ['e', 'editor'], ['4', 'edt'])
+        rt = run_traject_on_record('unc', rec)['creator_main']
+        expect(rt).to eq(['Doe, Jane, editor'])
+      end
+    end
+
+    context '100 has linked 880 field' do
+      it '(MTA) shows vernacular first' do
+        rec = make_rec
+        rec << MARC::DataField.new('100', ' ', '1',
+                                   ['6', '880-01'],
+                                   ['a', 'Murād, Saʻīd'],
+                                   ['c', '(Musician)'],
+                                   ['4', 'cmp'], ['4', 'prf'])
+        rec << MARC::DataField.new('880', ' ', '1',
+                                   ['6', '100-01/r'],
+                                   ['a', 'مراد، سعيد.'])
+        rt = run_traject_on_record('unc', rec)['creator_main']
+        expect(rt).to eq(['مراد، سعيد / Murād, Saʻīd (Musician), composer, performer'])
+      end
+    end
+  end
+
+  context 'record has no 100, 110, or 111 field' do
+    it '(MTA) does not fall over' do
+      rec = make_rec
+      rt = run_traject_on_record('unc', rec)['creator_main']
+      expect(rt).to be_nil
+    end
+  end
+  
+
+end

--- a/spec/macros/shared/statement_of_responsibility_spec.rb
+++ b/spec/macros/shared/statement_of_responsibility_spec.rb
@@ -21,48 +21,5 @@ describe MarcToArgot::Macros::Shared::StatementOfResponsibility do
                       )
   end
 
-  context 'When there is no 245$c value' do
-    it '(MTA) sets statement_of_responsibility from 100' do
-      rec = make_rec
-      rec << MARC::DataField.new('245', '1', '0', ['a', 'Title only'])
-      rec << MARC::DataField.new('100', '1', ' ', ['a', 'Name, Author,'], ['d', '1960-'])
-      argot = run_traject_on_record('unc', rec)
-      result = argot['statement_of_responsibility']
-      expect(result).to eq([
-                             { "value" => "Name, Author, 1960-" }
-                           ])
-    end
-    it '(MTA) sets statement_of_responsibility from 110 with linked 880' do
-      rec = make_rec
-      rec << MARC::DataField.new('245', '1', '0', ['a', 'Title only'])
-      rec << MARC::DataField.new('110', '2', ' ',
-                                 ['6', '880-01'],
-                                 ['a', 'Akademii͡a nauk SSSR.'],
-                                 ['b', 'Biblioteka.'])
-      rec << MARC::DataField.new('880', '2', ' ',
-                                 ['6', '110-01/(N'],
-                                 ['a', 'Академия наук СССР.'],
-                                 ['b', 'Библиотека.'])
 
-      argot = run_traject_on_record('unc', rec)
-      result = argot['statement_of_responsibility']
-      expect(result).to eq([
-                             { "value" => "Akademii͡a nauk SSSR. Biblioteka" },
-                             { "value" => "Академия наук СССР. Библиотека", "lang" => "rus" }
-                           ])
-    end
-    it '(MTA) sets statement_of_responsibility from vernacular in 111' do
-      rec = make_rec
-      rec << MARC::DataField.new('245', '1', '0', ['a', 'Title only'])
-      rec << MARC::DataField.new('111', '2', ' ',
-                                 ['a', 'Академия наук СССР.'],
-                                 ['b', 'Библиотека.'])
-      argot = run_traject_on_record('unc', rec)
-      result = argot['statement_of_responsibility']
-      expect(result).to eq([
-                             { "value" => "Академия наук СССР", "lang" => "rus" }
-                           ])
-    end
-
-  end
 end


### PR DESCRIPTION
Draft release: https://github.com/trln/marc-to-argot/releases/edit/untagged-4f4ede2139e45e79700d

Resolves https://trlnmain.atlassian.net/browse/TD-894

Produces a DISPLAY ONLY field showing the value from the 100, 110, or 111 if present in record. 

If there is a linked 880 field, that value is shown first, joined to transliterated value by ' / '

This is for display in search results view and above the fold in full record view, since the statement of responsibility does not always include the name of the creator. 

Is NOT indexed, because this name is still included in the names field, which handles the indexing. 