### PR TITLE
bug fix for names having open date ranges AND relators

### DIFF
--- a/lib/marc_to_argot/macros/shared/creator_main.rb
+++ b/lib/marc_to_argot/macros/shared/creator_main.rb
@@ -23,7 +23,11 @@ module MarcToArgot
           rel_part = names_rel(field)
 
           if rel_part.length > 0
-            name_part << ', ' unless name_part.end_with?('-')
+            if name_part.end_with?('-')
+              name_part << ' '
+            else
+              name_part << ', '
+            end
           end
 
           name_part + rel_part.join(', ')

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.4.20'.freeze
+  VERSION = '0.4.21'.freeze
 end

--- a/spec/macros/shared/creator_main_spec.rb
+++ b/spec/macros/shared/creator_main_spec.rb
@@ -6,9 +6,11 @@ describe MarcToArgot::Macros::Shared::CreatorMain do
   context 'record has 100 field' do
     it '(MTA) sets creator_main from 100' do
       rec = make_rec
-      rec << MARC::DataField.new('100', ' ', '1', ['a', 'Doe, Jane,'], ['d', '1970-'])
+      rec << MARC::DataField.new('100', ' ', '1', ['a', 'Doe, Jane,'],
+                                 ['d', '1970-'],
+                                 ['e', 'author'])
       rt = run_traject_on_record('unc', rec)['creator_main']
-      expect(rt).to eq(['Doe, Jane, 1970-'])
+      expect(rt).to eq(['Doe, Jane, 1970- author'])
     end
 
     context '100 has redundant $e and $4' do


### PR DESCRIPTION
Draft release https://github.com/trln/marc-to-argot/releases/edit/untagged-cb0df4cb9f1db711ad45

Adds space between name ending with open date range and any relator term(s)