### PR TITLE
NCSU: journal links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ sudo: false
 language: ruby
 rvm:
   - 2.4.5
-  - 2.5.1
+  - 2.5.3
+  - 2.6.2
 
 before_install: 
   - "find /home/travis/.rvm/rubies -wholename '*default/bundler-*.gemspec' -delete"
-  - gem install bundler --version 1.17.3
+  - gem install bundler

--- a/lib/data/ncsu/traject_config.rb
+++ b/lib/data/ncsu/traject_config.rb
@@ -52,15 +52,19 @@ each_record do |rec, ctx|
   #handle trln videos
   process_shared_records!(rec, ctx, urls)
   if serial?(rec)
-    libraries = items.map { |i| i['loc_b'] }.uniq
+    # throw out any catalogued URLs for serials, instead prefer
+    # journals link
+    if local?(ctx)
+      urls = ctx.output_hash['url'] = []
+    end
 
+    libraries = items.map { |i| i['loc_b'] }.uniq
+    loc_id = ctx.output_hash['local_id'].first[:value]
+    href = "https://www.lib.ncsu.edu/journals/more_info.php?catkey=#{loc_id}"
     if online_access?(rec, libraries)
-      loc_id = ctx.output_hash['local_id'].first[:value]
-      href = "https://www.lib.ncsu.edu/journals/more_info.php?catkey=#{loc_id}"
       urls << { type: 'fulltext', href: href, text: 'View available online access'}
     else
-      title_esc = URI.escape(ctx.output_hash['title_main'].first[:value])
-      href= "https://www.lib.ncsu.edu/journals/search.php?type=keywords&search=#{title_esc}"
+      # rely on matched records on catkey for link
       urls << { type: 'other', href: href, text: 'Search for online access' }
     end
   end
@@ -82,7 +86,6 @@ each_record do |rec, ctx|
       ctx.output_hash['physical_media'] = ['Online'] if access_type.include?('Online')
     end
   end
-
 
   remove_print_from_archival_material(ctx)
 

--- a/lib/marc_to_argot/command_line.rb
+++ b/lib/marc_to_argot/command_line.rb
@@ -96,6 +96,7 @@ module MarcToArgot
 
       # only set the output file if ''output' doesn't look like an IO object already.
       settings['output_file'] = output unless output.respond_to?(:read)
+      settings['processing_thread_pool'] = '6'
 
       conf_files = ["#{data_dir}/extensions.rb", "#{data_dir}/argot/traject_config.rb","#{data_dir}/#{collection}/traject_config.rb"]
 
@@ -141,7 +142,7 @@ module MarcToArgot
         end
       else
         warn(e)
-        warn(e.backrace.join("\t\n"))
+        warn(e.backtrace.join("\t\n"))
       end
       raise e
     end

--- a/lib/marc_to_argot/command_line.rb
+++ b/lib/marc_to_argot/command_line.rb
@@ -96,7 +96,6 @@ module MarcToArgot
 
       # only set the output file if ''output' doesn't look like an IO object already.
       settings['output_file'] = output unless output.respond_to?(:read)
-      settings['processing_thread_pool'] = '6'
 
       conf_files = ["#{data_dir}/extensions.rb", "#{data_dir}/argot/traject_config.rb","#{data_dir}/#{collection}/traject_config.rb"]
 

--- a/lib/marc_to_argot/macros/ncsu/item_utils.rb
+++ b/lib/marc_to_argot/macros/ncsu/item_utils.rb
@@ -1,0 +1,66 @@
+module MarcToArgot
+  module Macros
+    module NCSU
+      # Utilities for working with NCSU item records
+      module ItemUtils
+        def self.sort_items(items)
+          items.map { |i| SortableItem.new(i) }.sort.map(&:to_h)
+        rescue ArgumentError
+          warn("Unable to process #{items}")
+          items
+        end
+        # Dirty hack to allow sorting items in a way
+        # Symphony will not let us
+        class SortableItem
+          def initialize(hash)
+            @_h = hash
+          end
+
+          def library
+            @_h['loc_b']
+          end
+
+          def location
+            @_h['loc_n']
+          end
+
+          def callnum
+            @_h['call_no']
+          end
+
+          def scheme
+            @_h['cn_scheme']
+          end
+
+          def to_h
+            @_h
+          end
+
+          def lc_callnum?
+            @_h['cn_scheme'] == 'LC'
+          end
+
+          def lcpad
+            @lcpad ||= Lcsort.normalize(@_h['call_no']) if lc_callnum?
+          end
+
+          def <=>(other)
+            libcomp = library <=> other.library
+            return libcomp unless libcomp.zero?
+
+            loccomp = location <=> other.location
+            return loccomp unless loccomp.zero?
+
+            return -1 if lc_callnum? && !other.lc_callnum?
+
+            return 1 if other.lc_callnum? && !lc_callnum?
+
+            return lcpad <=> other.lcpad if lcpad && other.lcpad
+
+            callnum <=> other.callnum || 0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/marc_to_argot/macros/ncsu/items.rb
+++ b/lib/marc_to_argot/macros/ncsu/items.rb
@@ -213,6 +213,7 @@ module MarcToArgot
                 acc << item.to_json if item 
               end
             end
+            items = MarcToArgot::Macros::NCSU::ItemUtils.sort_items(items)
             populate_context!(items, rec, ctx)
             map_call_numbers!(ctx, items)
           end

--- a/lib/marc_to_argot/macros/ncsu/items.rb
+++ b/lib/marc_to_argot/macros/ncsu/items.rb
@@ -143,7 +143,7 @@ module MarcToArgot
           lib, loc = get_location(item)
           lib_cases = lib == 'SPECCOLL'
           loc_cases = case loc
-                      when 'GAMELAB', 'VRSTUDIO', /^SPEC/, /^REF/
+                      when 'GAMELAB', /^VR/, /^SPEC/, /^REF/
                         true
                       else
                         false

--- a/lib/marc_to_argot/macros/ncsu_macros.rb
+++ b/lib/marc_to_argot/macros/ncsu_macros.rb
@@ -89,6 +89,10 @@ module MarcToArgot
         end
       end
 
+      def local?(ctx)
+        ctx.output_hash['institution'] == ['ncsu']
+      end
+
       def is_available?(items)
         items.any? { |i| i.fetch('status', '').match?(/^avail/i) || i['loc_b'] == 'ONLINE' }
       end

--- a/lib/marc_to_argot/macros/ncsu_macros.rb
+++ b/lib/marc_to_argot/macros/ncsu_macros.rb
@@ -5,6 +5,7 @@ module MarcToArgot
     # Macros for NCSU-specific tasks
     module NCSU
       require 'marc_to_argot/macros/ncsu/summaries'
+      require 'marc_to_argot/macros/ncsu/item_utils'
       require 'marc_to_argot/macros/ncsu/items'
       require 'marc_to_argot/macros/ncsu/physical_media'
       require 'marc_to_argot/macros/ncsu/resource_type'

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.4.21'.freeze
+  VERSION = '0.4.22'.freeze
 end

--- a/marc_to_argot.gemspec
+++ b/marc_to_argot.gemspec
@@ -34,16 +34,15 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_development_dependency 'bundler', '>= 1.16'
+  s.add_development_dependency 'bundler', '~> 2.0'
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'yajl-ruby', '>= 1.3.1'
 
   # pick our JSON library to install depending on the platform
   if is_java
     s.platform = 'java'
     s.add_runtime_dependency 'jar-dependencies', ['~> 0.3', '>=0.3.9']
-    s.requirements << 'jar org.noggit:noggit, 0.7'
+    s.requirements << 'jar org.noggit:noggit, 0.8'
   else
     s.platform = 'ruby'
     s.add_runtime_dependency 'yajl-ruby', ['>=1.3.1']

--- a/spec/data/ncsu/ejournal_with_856.xml
+++ b/spec/data/ncsu/ejournal_with_856.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<collection
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd"
+  xmlns="http://www.loc.gov/MARC21/slim">
+<record>
+  <leader>01741nas a2200397 a 4500</leader>
+  <controlfield tag="001">ocm72549382</controlfield>
+  <controlfield tag="003">OCoLC</controlfield>
+  <controlfield tag="005">20080805092136.0</controlfield>
+  <controlfield tag="006">m        d        </controlfield>
+  <controlfield tag="007">cr cn#||||||||</controlfield>
+  <controlfield tag="008">061011c20059999cauar   s     1    0eng d</controlfield>
+  <datafield tag="010" ind1=" " ind2=" ">
+    <subfield code="a">  2008242209</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)72549382</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">SUC</subfield>
+    <subfield code="c">SUC</subfield>
+    <subfield code="d">SUC</subfield>
+    <subfield code="d">MYG</subfield>
+  </datafield>
+  <datafield tag="042" ind1=" " ind2=" ">
+    <subfield code="a">lcd</subfield>
+  </datafield>
+  <datafield tag="049" ind1=" " ind2=" ">
+    <subfield code="a">NRCC</subfield>
+    <subfield code="x">amb</subfield>
+  </datafield>
+  <datafield tag="090" ind1=" " ind2=" ">
+    <subfield code="a">QA76.575 e-journal</subfield>
+  </datafield>
+  <datafield tag="111" ind1="2" ind2=" ">
+    <subfield code="a">International Conference on Automated Production of Cross Media Content for Multi-channel Distribution.</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Proceedings</subfield>
+    <subfield code="h">[electronic resource] /</subfield>
+    <subfield code="c">International Conference on Automated Production of Cross Media Content for Multi-channel Distribution.</subfield>
+  </datafield>
+  <datafield tag="246" ind1="1" ind2="3">
+    <subfield code="a">AXMEDIS</subfield>
+  </datafield>
+  <datafield tag="246" ind1="3" ind2=" ">
+    <subfield code="a">International Conference on Automated Production of Cross Media Content for Multi-channel Distribution</subfield>
+  </datafield>
+  <datafield tag="246" ind1="1" ind2=" ">
+    <subfield code="i">IEEExplore title:</subfield>
+    <subfield code="a">Automated Production of Cross Media Content for Multi-channel Distribution, International Conference on</subfield>
+  </datafield>
+  <datafield tag="260" ind1=" " ind2=" ">
+    <subfield code="a">Los Alamitos, Calif. :</subfield>
+    <subfield code="b">IEEE Computer Society,</subfield>
+    <subfield code="c">c2005-</subfield>
+  </datafield>
+  <datafield tag="310" ind1=" " ind2=" ">
+    <subfield code="a">Annual</subfield>
+  </datafield>
+  <datafield tag="362" ind1="1" ind2=" ">
+    <subfield code="a">Began with 1st (30 Nov.-2 Dec. 2005).</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Description based on first issue; title from PDF of title page (IEEExplore, viewed Aug. 4, 2008).</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Latest issue consulted: 3rd (28-30 Nov. 2007).</subfield>
+  </datafield>
+  <datafield tag="538" ind1=" " ind2=" ">
+    <subfield code="a">Mode of Access: World Wide Web.</subfield>
+  </datafield>
+  <datafield tag="596" ind1=" " ind2=" ">
+    <subfield code="a">8</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Multimedia systems</subfield>
+    <subfield code="x">Data processing</subfield>
+    <subfield code="v">Congresses.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Music</subfield>
+    <subfield code="x">Data processing</subfield>
+    <subfield code="v">Congresses.</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="0">
+    <subfield code="u">http://proxying.lib.ncsu.edu/index.php?url=http://ieeexplore.ieee.org/xpl/conhome.jsp?punumber=1001526</subfield>
+  </datafield>
+  <datafield tag="909" ind1=" " ind2=" ">
+    <subfield code="a">20071109</subfield>
+  </datafield>
+  <datafield tag="918" ind1=" " ind2=" ">
+    <subfield code="a">1993971</subfield>
+  </datafield>
+  <datafield tag="994" ind1=" " ind2=" ">
+    <subfield code="a">C0</subfield>
+    <subfield code="b">NRC</subfield>
+  </datafield>
+  <datafield tag="999" ind1=" " ind2=" ">
+    <subfield code="a">QA76.575 E-JOURNAL</subfield>
+    <subfield code="w">LC</subfield>
+    <subfield code="c">1</subfield>
+    <subfield code="i">1993971-1001</subfield>
+    <subfield code="l">NET</subfield>
+    <subfield code="m">ONLINE</subfield>
+    <subfield code="r">Y</subfield>
+    <subfield code="s">Y</subfield>
+    <subfield code="t">EJOURNAL</subfield>
+    <subfield code="u">11/9/2007</subfield>
+  </datafield>
+</record>
+</collection>

--- a/spec/macros/ncsu/urls_spec.rb
+++ b/spec/macros/ncsu/urls_spec.rb
@@ -12,6 +12,8 @@ describe MarcToArgot::Macros do
   let(:multiple_url_note_record) { run_traject_json('ncsu', 'multiple-856-notes') }
   let(:empty_url_note_record) { run_traject_json('ncsu', 'empty-856-notes') }
 
+  let(:ejournal_with_856) { run_traject_json('ncsu', 'ejournal_with_856') }
+
   context 'NCSU' do
     it 'outputs restricted=false if there is an 856 and online and open access' do
       urls = open_access_record['url'].map { |u| JSON.parse(u) }
@@ -41,6 +43,17 @@ describe MarcToArgot::Macros do
     it 'should not output url["note"] when 856$3$z are empty' do
       url = empty_url_note_record['url'].map { |u| JSON.parse(u) }.first
       expect(url['note']).to be_nil
+    end
+
+    context 'Journals' do 
+
+      it 'should only output a link to journals if 856 is present' do
+        local_id = ejournal_with_856['local_id']['value']
+        urls = ejournal_with_856['url'].map { |u| JSON.parse(u) }
+        expect(ejournal['institution']).to eq(['ncsu'])
+        expect(urls.length).to eq(1)
+        expect(urls.first['href']).to include("catkey=#{local_id}")
+      end
     end
   end
 end

--- a/spec/macros/ncsu_macros_spec.rb
+++ b/spec/macros/ncsu_macros_spec.rb
@@ -14,7 +14,8 @@ describe MarcToArgot::Macros::NCSU do
     records.each_with_index do |rec, idx|
       output = indexer.map_record(rec)
       exp = expected_rollups[idx]
-      expect(output.length).to eq(exp.length), "Record #{idx +1} in error, output #{output}, expected #{exp}" unless exp.nil?
+      index = idx + 1
+      expect(output.length).to eq(exp.length), "Record #{index} in error, output #{output}, expected #{exp}" unless exp.nil?
       expect(output['rollup_id']).to eq(exp)
     end
   end

--- a/spec/ncsu/ncsu_barcode_spec.rb
+++ b/spec/ncsu/ncsu_barcode_spec.rb
@@ -22,7 +22,7 @@ describe MarcToArgot do
   it 'generates multiple barcodes for test record' do
     barcodes = multi_barcode['barcodes']
     expect(barcodes).to be_a(Array)
-    expect(barcodes).to eq(expected_barcodes)
+    expect(barcodes).to match_array(expected_barcodes)
   end
 
   it 'generates empty barcode attribute for record with no barcoded items' do

--- a/spec/ncsu/ncsu_urls_spec.rb
+++ b/spec/ncsu/ncsu_urls_spec.rb
@@ -6,11 +6,20 @@ describe MarcToArgot do
   # this file is a bit pathological, it has three identical URLs
   let(:findingaid) { run_traject_json('ncsu', 'multi-findingaid-856') }
 
+  let(:ejournal) { run_traject_json('ncsu', 'ejournal') }
+
   it 'generates 856s for every one in the document' do
     expect(findingaid['url']).to be_a(Array)
     urls = findingaid['url'].map { |x| JSON.parse(x) }
     expect(urls.length).to eq(3)
     findingaids = urls.select { |x| x['type'] == 'findingaid' }
     expect(findingaids.length).to eq(3)
+  end
+
+  it 'generates a link to journals app for Journal' do
+    url = ejournal['url'].map{ |x| JSON.parse(x) }
+    expect(url).to be_a(Array)
+    expect(url.length).to eq(1)
+    expect(url.first['href']).to include("catkey=#{ejournal['local_id']['value']}")
   end
 end

--- a/spec/util.rb
+++ b/spec/util.rb
@@ -1,7 +1,11 @@
 require 'yaml'
 require 'traject'
 require 'marc_to_argot'
-require 'yajl'
+if RUBY_PLATFORM =~ /java/
+  java_import 'org.noggit.ObjectBuilder'
+else
+  require 'yajl'
+end
 
 # Utilities for specs
 module Util


### PR DESCRIPTION
All journals now link via catkey to NCSU journals application (no more searching on title)
Items sorted by LC call number when available.
Change item status for "VR" locations.