### PR TITLE
ncsu update item statuses

### DIFF
--- a/lib/marc_to_argot/macros/ncsu/items.rb
+++ b/lib/marc_to_argot/macros/ncsu/items.rb
@@ -19,7 +19,7 @@ module MarcToArgot
 
         NO_FACET_LOCATIONS = %w[ONLINE BBR].freeze
 
-        MAINS = Set.new(%w[DHILL HUNT]).freeze
+        MAINS = Set.new(%w[DHHILL HUNT BOOKBOT]).freeze
 
         # locations that map to virtual collections
         # library does not matter for these, EXCEPT for LRL/TEXTBOOK
@@ -63,9 +63,15 @@ module MarcToArgot
           [item['loc_b'], item['loc_n']]
         end
 
+        # FOURTHFLOORCLOSURE
+        def hill_fourth_floor?(item)
+          cn = item.fetch('call_no', '')
+          item['loc_b'] == 'DHHILL' && item['loc_n'] == 'STACKS' && ( 'A' <= cn &&cn <= 'DB' )
+        end
+
         # Offsite & requestable
         def offsite?(item)
-          return true if OFFSITE_LIB.include?(item['loc_b'])
+          return true if OFFSITE_LIB.include?(item['loc_b']) || hill_fourth_floor?(item)
 
           case item['loc_b']
           when 'SPECCOLL'
@@ -149,11 +155,15 @@ module MarcToArgot
                         false
                       end
           type_cases = case item['type']
-                       when 'BOOKNOCIRC', 'SERIAL', 'MAP', 'CD-ROM-NC'
+                       when 'SERIAL'
+                        # Hill, Hunt circulate; others do not
+                         !MAINS.include?(lib)
+                       when 'BOOKNOCIRC', 'MAP', 'CD-ROM-NC'
                          true
                        else
                          false
                        end
+
           lib_cases || loc_cases || type_cases
         end
 

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.4.24'.freeze
+  VERSION = '0.4.25'.freeze
 end

--- a/spec/data/ncsu/items.yml
+++ b/spec/data/ncsu/items.yml
@@ -12,6 +12,12 @@
     :w: cn_scheme
     :z: item_cat_2
 
+:hill_stacks: &HILLSTACKS
+  :m: DHHILL
+  :l: STACKS
+  :w: LC
+  :k: STACKS
+
 :no_copy_no:
     :i: SN0C0PY
     :m: DHHILL
@@ -28,3 +34,36 @@
 
 :item_note:
     :o: .STAFF. spine falling apart
+
+# FOURTHFLOORCLOSURE
+:fourth_floor_item:
+  :m: DHHILL
+  :l: STACKS
+  :a: BC 101 .Q298
+
+# FOURTHFLOORCLOSURE
+:fifth_floor_item:
+  :m: DHHILL
+  :l: STACKS
+  :a: EM 101 .Q298
+
+# FOURTHFLOORCLOSURE
+:hunt_ff_range_item:
+  :m: HUNT
+  :l: STACKS
+  :a: BC 101 .Q298
+
+
+:hill_serial:
+  <<: *HILLSTACKS
+  :t: SERIAL
+
+:hunt_serial:
+  <<: *HILLSTACKS
+  :t: SERIAL
+  :m: HUNT
+
+:design_serial:
+  <<: *HILLSTACKS
+  :m: DESIGN
+  :t: SERIAL

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'util'
 require 'marc/record'
 
 RSpec.configure do |c|
+  c.example_status_persistence_file_path = "spec/reports/rspec.txt"
   c.include Util::TrajectRunTest
 end
 


### PR DESCRIPTION
Prepares for circulation policy changes and closure of fourth floor at Hill:

- items on fourth floor at hill now have 'library use only' in status
- serials at Hill, Hunt, and bookBot now circulate (remove 'library use only')