### PR TITLE
set pub year to current plus one if it's 9999

### DIFF
--- a/lib/marc_to_argot/macros/shared/publication_year.rb
+++ b/lib/marc_to_argot/macros/shared/publication_year.rb
@@ -4,10 +4,15 @@ module MarcToArgot
       module PublicationYear
 
         # Gets called from traject_config to populate the publication_year field
+        # Uses following configuration parameters:
         #  min_year: earliest date we consider to be a usable publication date
         #    Defaults to 500.
         #  max_year: latest date we consider to be a usable publication date
         #    Defaults to current year, plus 6 (due to ridiculous publisher shenanigans)
+        #  cont_pub_max_year: date to use for continuing resources when they 
+        #  are otherwise found to set the publication date to 9999.
+        #    Defaults to current year plus one.
+        #    
         #  range_tolerance: Maximum range we think is informative enough to set a
         #    publication_year from.
         #    Default so 500, which basically just throws out dates where we only know
@@ -16,10 +21,13 @@ module MarcToArgot
           min_year            = options[:min_year] || 500
           max_year            = options[:max_year] || (Time.new.year + 6)
           range_tolerance     = options[:range_tolerance] || 500
+          # max year to show for continuing resources
+          cont_pub_max_year   = options[:cont_pub_max_year] || Time.new().year + 1
           
           lambda do |rec, acc|
             date = set_year_from_008(rec, min_year, max_year, range_tolerance) if field_present?(rec, '008')
             date = set_year_from_varfield(rec, min_year, max_year, range_tolerance) if date == nil
+            date = cont_pub_max_year if date&.to_i == 9999
             acc << date if date
           end
         end

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.4.26'.freeze
+  VERSION = '0.4.27'.freeze
 end

--- a/spec/macros/shared/publication_year_spec.rb
+++ b/spec/macros/shared/publication_year_spec.rb
@@ -6,6 +6,10 @@ include MarcToArgot::Macros::Shared::PublicationYear
 describe MarcToArgot do
   include Util::TrajectRunTest
   describe MarcToArgot::Macros::Shared::PublicationYear do
+
+    # 9999 should translate to current year + 1
+    let (:continuing_resource_max) { Time.now.year + 1 }
+
     context 'DateType = b' do
       context 'AND no 260/4 date' do
         it '(MTA) does not set date' do
@@ -38,7 +42,7 @@ describe MarcToArgot do
         rec = make_rec
         rec['008'].value[6..14] = 'c20129999'
         argot = run_traject_on_record('unc', rec)
-        expect(argot['publication_year']).to eq([9999])
+        expect(argot['publication_year']).to eq([continuing_resource_max])
       end
       it '(MTA) does not set from unusable date2' do
         rec = make_rec
@@ -266,11 +270,12 @@ describe MarcToArgot do
     end
 
     context 'DateType = u' do
+
       it '(MTA) sets from usable date2 if present --- 9999 is considered usable' do
         rec = make_rec
         rec['008'].value[6..14] = 'u20129999'
         argot = run_traject_on_record('unc', rec)
-        expect(argot['publication_year']).to eq([9999])
+        expect(argot['publication_year']).to eq([continuing_resource_max])
       end
       it '(MTA) sets from usable date1 if no usable date2' do
         rec = make_rec


### PR DESCRIPTION
TD-898: to avoid showing 9999 as the end of the publication year date range in the slider widget, translate that value to current year + 1.