### PR TITLE
Td 935 no unc items on shared oupp

### DIFF
--- a/lib/data/unc/traject_config.rb
+++ b/lib/data/unc/traject_config.rb
@@ -78,7 +78,7 @@ each_record do |rec, cxt|
 
   # set EAD id
   set_ead_id(rec, cxt)
-  
+
   # unless staff have added print item/holdings to DWS shared records
   # create items and holdings
   unless cxt.clipboard[:shared_record_set] == 'dws'
@@ -98,10 +98,10 @@ each_record do |rec, cxt|
   # set location_hierarchy and available fields from real and dummy items
   location_hierarchy(rec, cxt)
   available(rec, cxt) if out['items']
-  
+
   # add genre_mrc field
   local_subject_genre(rec, cxt)
-  
+
   # Add and manipulate fields for TRLN shared records and other special record groups
   case cxt.clipboard[:shared_record_set]
   when 'asp'

--- a/lib/marc_to_argot/macros/unc/items.rb
+++ b/lib/marc_to_argot/macros/unc/items.rb
@@ -13,6 +13,13 @@ module MarcToArgot
             barcodes = items.map { |i| i['barcode'] }.compact
             cxt.output_hash['barcodes'] = barcodes if barcodes.length > 0
 
+          # non-OUPP items mistakenly cataloged on OUPP shared records display
+          # in the local scope of non-UNC institutions (and make UNC locs
+          # appear in the facets), so do not output them.
+          if cxt.clipboard[:shared_record_set] == 'oupp'
+            items.select! { |i| i['loc_b'] == 'troup' }
+          end
+
             items = items.map { |i| i.delete('barcode'); i.to_json }
             
             cxt.output_hash['items'] = items if items.length > 0

--- a/lib/marc_to_argot/macros/unc/items.rb
+++ b/lib/marc_to_argot/macros/unc/items.rb
@@ -4,14 +4,14 @@ module MarcToArgot
       module Items
 
         def items(rec, cxt)
-            items = []
-            Traject::MarcExtractor.cached('999|*1|cdilnpqsv', alternate_script: false).each_matching_line(rec) do |field, spec, extractor|
-              items << assemble_item(field)
-            end
+          items = []
+          Traject::MarcExtractor.cached('999|*1|cdilnpqsv', alternate_script: false).each_matching_line(rec) do |field, spec, extractor|
+            items << assemble_item(field)
+          end
 
-            #set barcodes field
-            barcodes = items.map { |i| i['barcode'] }.compact
-            cxt.output_hash['barcodes'] = barcodes if barcodes.length > 0
+          #set barcodes field
+          barcodes = items.map { |i| i['barcode'] }.compact
+          cxt.output_hash['barcodes'] = barcodes if barcodes.length > 0
 
           # non-OUPP items mistakenly cataloged on OUPP shared records display
           # in the local scope of non-UNC institutions (and make UNC locs
@@ -20,10 +20,10 @@ module MarcToArgot
             items.select! { |i| i['loc_b'] == 'troup' }
           end
 
-            items = items.map { |i| i.delete('barcode'); i.to_json }
-            
-            cxt.output_hash['items'] = items if items.length > 0
-       end
+          items = items.map { |i| i.delete('barcode'); i.to_json }
+
+          cxt.output_hash['items'] = items if items.length > 0
+        end
 
         def assemble_item(field)
           item = { 'notes' => [] }
@@ -34,7 +34,7 @@ module MarcToArgot
 
           # https://github.com/trln/extract_marcxml_for_argot_unc/blob/master/attached_record_data_mapping.csv
           field.subfields.each do |subfield|
-            
+
             sf = subfield.code
             subfield.value.gsub!(/\|./, ' ') #remove subfield delimiters and
             subfield.value.strip! #delete leading/trailing spaces
@@ -83,14 +83,14 @@ module MarcToArgot
           end
 
           if item.has_key?('call_no')
-            item['cn_scheme'] = set_cn_scheme(call_no_tag, call_no_i1, call_no_i2)            
+            item['cn_scheme'] = set_cn_scheme(call_no_tag, call_no_i1, call_no_i2)
           end
 
           item.delete('notes') if item['notes'].length == 0
-          
+
           item
         end
-        
+
         def status_map
           @status_map ||=Traject::TranslationMap.new('unc/status_map')
         end

--- a/lib/marc_to_argot/macros/unc/items.rb
+++ b/lib/marc_to_argot/macros/unc/items.rb
@@ -37,7 +37,7 @@ module MarcToArgot
             when 'c'
               item['copy_no'] = 'c. ' + subfield.value if subfield.value != '1'
             when 'd'
-              item['due_date'] = subfield.value.gsub('-', '')
+              item['due_date'] = subfield.value
             when 'i'
               item['item_id'] = subfield.value
             when 'l'

--- a/lib/marc_to_argot/macros/unc/items.rb
+++ b/lib/marc_to_argot/macros/unc/items.rb
@@ -45,6 +45,14 @@ module MarcToArgot
               item['copy_no'] = 'c. ' + subfield.value if subfield.value != '1'
             when 'd'
               item['due_date'] = subfield.value
+            when 'h'
+              next if subfield.value == '0'
+
+              if subfield.value == '1'
+                item['notes'] << '1 hold currently placed on this item'
+              else
+                item['notes'] << "#{subfield.value} holds currently placed on this item"
+              end
             when 'i'
               item['item_id'] = subfield.value
             when 'l'

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.4.38'.freeze
+  VERSION = '0.4.39'.freeze
 end

--- a/spec/macros/unc/items_spec.rb
+++ b/spec/macros/unc/items_spec.rb
@@ -183,7 +183,7 @@ describe MarcToArgot::Macros::UNC::Items do
         'u' => 'Not Available',
         'v' => 'At the Bindery',
         'w' => 'Withdrawn',
-        'z' => 'Missing',        
+        'z' => 'Missing',
       }
 
       rules.each do |code, label|

--- a/spec/macros/unc/items_spec.rb
+++ b/spec/macros/unc/items_spec.rb
@@ -290,4 +290,30 @@ describe MarcToArgot::Macros::UNC::Items do
     end
   end
 
+  describe 'set note providing hold count' do
+    context 'WHEN there are no holds on the item' do
+      it '(UNC) adds no hold count note' do
+        field = MARC::DataField.new('999', '9', '1',
+                                    ['h', '0'])
+        result = assemble_item(field)['notes']
+        expect(result).to be_nil
+      end
+    end
+
+    context 'WHEN there are holds on the item' do
+      it '(UNC) adds a hold count note' do
+        field = MARC::DataField.new('999', '9', '1',
+                                    ['h', '2'])
+        result = assemble_item(field)['notes']
+        expect(result).to eq(['2 holds currently placed on this item'])
+      end
+
+      it '(UNC) uses proper pluralization for a hold count of 1' do
+        field = MARC::DataField.new('999', '9', '1',
+                                    ['h', '1'])
+        result = assemble_item(field)['notes']
+        expect(result).to eq(['1 hold currently placed on this item'])
+      end
+    end
+  end
 end

--- a/spec/macros/unc/items_spec.rb
+++ b/spec/macros/unc/items_spec.rb
@@ -201,22 +201,22 @@ describe MarcToArgot::Macros::UNC::Items do
         end
       end
 
-      context "AND item has a due date value (2066-6-6)" do
+      context "AND item has a due date value (2019-01-02 03:04:00-05)" do
         it '(UNC) items[status] = Checked Out' do
           rec = make_rec
           rec << MARC::DataField.new('999', '9', '1',
                                      ['s', '-'],
-                                     ['d', '2066-06-06'])
+                                     ['d', '2019-01-02 03:04:00-05'])
           result = run_traject_on_record('unc', rec)['items']
           expect(result[0]).to( include("\"status\":\"Checked Out\"") )
         end
-        it '(UNC) items[due_date] = 20660606' do
+        it '(UNC) items[due_date] = 2019-01-02 03:04:00-05' do
           rec = make_rec
           rec << MARC::DataField.new('999', '9', '1',
                                      ['s', '-'],
-                                     ['d', '2066-06-06'])
+                                     ['d', '2019-01-02 03:04:00-05'])
           result = run_traject_on_record('unc', rec)['items']
-          expect(result[0]).to( include("\"due_date\":\"20660606\"") )
+          expect(result[0]).to include("\"due_date\":\"2019-01-02 03:04:00-05\"")
         end
       end
     end

--- a/spec/macros/unc/shared_record_spec.rb
+++ b/spec/macros/unc/shared_record_spec.rb
@@ -29,6 +29,13 @@ describe MarcToArgot::Macros::UNC::SharedRecords do
       result = id_shared_record_set(rec)
       expect(result).to eq('crl')
     end
+
+    it 'identifies OUPP records' do
+      rec = make_rec
+      rec << MARC::DataField.new('919', ' ', ' ', ['a', 'TROUP'])
+      result = id_shared_record_set(rec)
+      expect(result).to eq('oupp')
+  end
   end
 
   context 'When there is a 919 field containing filmfinder' do
@@ -66,6 +73,26 @@ describe MarcToArgot::Macros::UNC::SharedRecords do
       expect(result).to eq(
                           ['TRLN Shared Records. Oxford University Press print titles.']
                         )
+    end
+
+    context 'When non-OUPP items are present on a OUPP record' do
+      let(:rec) do
+        rec = make_rec
+        rec << MARC::DataField.new('919', ' ', ' ', ['a', 'TROUP'])
+        rec << MARC::DataField.new('999', '9', '1', ['l', "ddda"])
+        rec << MARC::DataField.new('999', '9', '1', ['l', "troup"])
+        rec
+      end
+
+      it '(UNC) non-OUPP items are removed' do
+        result = run_traject_on_record('unc', rec)['items']
+        expect(result.find { |i| i.include? 'ddda' }).to be_nil
+      end
+
+      it '(UNC) OUPP items remain' do
+        result = run_traject_on_record('unc', rec)['items']
+        expect(result.find { |i| i.include? "loc_b\":\"troup" }).to be_truthy
+      end
     end
   end
 

--- a/spec/macros/unc/shared_record_spec.rb
+++ b/spec/macros/unc/shared_record_spec.rb
@@ -35,7 +35,7 @@ describe MarcToArgot::Macros::UNC::SharedRecords do
       rec << MARC::DataField.new('919', ' ', ' ', ['a', 'TROUP'])
       result = id_shared_record_set(rec)
       expect(result).to eq('oupp')
-  end
+    end
   end
 
   context 'When there is a 919 field containing filmfinder' do
@@ -47,7 +47,7 @@ describe MarcToArgot::Macros::UNC::SharedRecords do
       expect(result).to eq(['UNC MRC FilmFinder online and special materials'])
     end
   end
-  
+
   context 'When shared record set is OUPP' do
     it '(UNC) does NOT set TRLN location facet hierarchy for TRLN shared print' do
       result = troup1['location_hierarchy']
@@ -139,17 +139,17 @@ describe MarcToArgot::Macros::UNC::SharedRecords do
     it '(UNC) sets open access URL' do
       result = dwsgpo1['url']
       expect(result).to include(
-                          "{\"href\":\"http://purl.access.gpo.gov/GPO/LPS2957\",\"type\":\"fulltext\",\"restricted\":\"false\"}"                            
+                          "{\"href\":\"http://purl.access.gpo.gov/GPO/LPS2957\",\"type\":\"fulltext\",\"restricted\":\"false\"}"
                       )
     end
 
     it '(UNC) sets open access URL without discarding $3 values' do
       result = dwsgpo2['url']
       expect(result).to include(
-                          "{\"href\":\"http://purl.access.gpo.gov/GPO/LPS32255\",\"type\":\"fulltext\",\"note\":\"Spanish\",\"restricted\":\"false\"}"                            
+                          "{\"href\":\"http://purl.access.gpo.gov/GPO/LPS32255\",\"type\":\"fulltext\",\"note\":\"Spanish\",\"restricted\":\"false\"}"
                         )
     end
-    
+
     it '(UNC) record_data_source includes "Shared Records" and "DWS"' do
       result = dwsgpo1['record_data_source']
       expect(result).to eq(
@@ -178,7 +178,7 @@ describe MarcToArgot::Macros::UNC::SharedRecords do
       result = asp1['url']
       expect(result).to eq(
                           [
-                            "{\"href\":\"{+proxyPrefix}https://www.aspresolver.com/aspresolver.asp?ANTH;764084\",\"type\":\"fulltext\"}"                            
+                            "{\"href\":\"{+proxyPrefix}https://www.aspresolver.com/aspresolver.asp?ANTH;764084\",\"type\":\"fulltext\"}"
                           ]
                         )
     end
@@ -187,7 +187,7 @@ describe MarcToArgot::Macros::UNC::SharedRecords do
       result = asp2['url']
       expect(result).to eq(
                           [
-                            "{\"href\":\"{+proxyPrefix}https://www.aspresolver.com/aspresolver.asp?ANTH;764084\",\"type\":\"fulltext\",\"note\":\"Part 3\"}"                            
+                            "{\"href\":\"{+proxyPrefix}https://www.aspresolver.com/aspresolver.asp?ANTH;764084\",\"type\":\"fulltext\",\"note\":\"Part 3\"}"
                           ]
                         )
     end
@@ -217,7 +217,7 @@ describe MarcToArgot::Macros::UNC::SharedRecords do
       expect(result).to eq(
                           ['Access limited to authenticated users. Unlimited simultaneous users.']
                         )
-    end    
+    end
   end
 
 end


### PR DESCRIPTION
**Shared**
- Do not output UNC-only items mistakenly present on shared OUPP bibs

**UNC only**
- Output count of item holds in item note
- Stop removing hyphens from item due date string