### PR TITLE
UNC donor notes and physical_media

### DIFF
--- a/lib/data/unc/overrides.yml
+++ b/lib/data/unc/overrides.yml
@@ -1,4 +1,5 @@
 # Argot attributes you do not want parsed by the default argot configuration
+- access_type
 - cataloged_date
 - donor
 - id
@@ -8,6 +9,7 @@
 - note_local
 - note_use_terms
 - oclc_number
+- physical_media
 - resource_type
 - rollup_id
 - sersol_number

--- a/lib/data/unc/traject_config.rb
+++ b/lib/data/unc/traject_config.rb
@@ -24,44 +24,12 @@ to_field 'resource_type', resource_type
 # set virtual_collection from 919$t
 to_field 'virtual_collection', extract_marc(settings['specs'][:virtual_collection], :separator => nil)
 
-def process_donor_marc(rec)
-  donors = []
-  Traject::MarcExtractor.cached('790|0 |abcdgqu:791|2 |abcdfg', alternate_script: false).each_matching_line(rec) do |field, spec, extractor|
-    if field.tag == '790'
-      included_sfs = %w[a b c d g q u]
-      value = []
-      field.subfields.each { |sf| value << sf.value if included_sfs.include?(sf.code) }
-      value = value.join(' ').chomp(',')
-      if value.start_with?('From the library of')
-        donors << { 'value' => value }
-      else
-        donors << {'value' => "Donated by #{value}"}
-      end
-    else field.tag == '791'
-      included_sfs = %w[a b c d f g]
-      value = []
-      field.subfields.each { |sf| value << sf.value if included_sfs.include?(sf.code) }
-      value = value.join(' ').chomp(',')
-      donors << {'value' => "Purchased using funds from the #{field.value}"}
-    end
-  end
-  return donors
-end
-
 to_field 'donor' do |rec, acc|
   donors = process_donor_marc(rec)
   donors.each { |d| acc << d } if donors.size > 0
 end
 
 to_field "note_local", note_local
-
-each_record do |rec, context|
-  donors = process_donor_marc(rec)
-  if donors.size > 0
-    context.output_hash['note_local'] ||= []
-    donors.each { |d| context.output_hash['note_local'] << d }
-  end
-end
 
 each_record do |rec, cxt|
   out = cxt.output_hash
@@ -132,6 +100,7 @@ each_record do |rec, cxt|
     cxt.output_hash['record_data_source'] = ['MARC', 'NCDHC']
   end
 
+  add_donors_as_local_notes(cxt)
   set_entity_ids!(cxt)
 
   remove_print_from_archival_material(cxt)

--- a/lib/data/unc/traject_config.rb
+++ b/lib/data/unc/traject_config.rb
@@ -100,7 +100,7 @@ each_record do |rec, cxt|
     cxt.output_hash['record_data_source'] = ['MARC', 'NCDHC']
   end
 
-  add_donors_as_local_notes(cxt)
+  add_donors_as_indexed_only_local_notes(cxt)
   set_entity_ids!(cxt)
 
   remove_print_from_archival_material(cxt)

--- a/lib/marc_to_argot/macros/unc/urls.rb
+++ b/lib/marc_to_argot/macros/unc/urls.rb
@@ -49,6 +49,7 @@ module MarcToArgot
           %w[incommon:unc.edu
              ebookcentral.proquest.com
              overdrive.com
+             panopto.com
              swankmp.net
              unc.kanopy.com
              unc.kanopystreaming.com

--- a/lib/marc_to_argot/macros/unc_macros.rb
+++ b/lib/marc_to_argot/macros/unc_macros.rb
@@ -97,10 +97,10 @@ module MarcToArgot
         donors
       end
 
-      def add_donors_as_local_notes(ctx)
+      def add_donors_as_indexed_only_local_notes(ctx)
         return unless ctx.output_hash.key?('donor')
 
-        donor = ctx.output_hash['donor']
+        donor = ctx.output_hash['donor'].map { |d| {'indexed_value' => d['value']} }
         local_notes = ctx.output_hash.fetch('note_local', [])
         ctx.output_hash['note_local'] = local_notes.concat(donor)
       end

--- a/lib/marc_to_argot/macros/unc_macros.rb
+++ b/lib/marc_to_argot/macros/unc_macros.rb
@@ -40,23 +40,21 @@ module MarcToArgot
       end
 
       # tests whether the record has any physical items
-      # this implementation asks whether there are any 999 fields that:
-      #  - have i1=9 (in all records, dates are output to 999 w/i1=0), and
-      #  - have i2<3 (i.e. an unsuppressed item or holding record exists)
+      # Because some items/holdings encoded in the marc are ignored
+      # (e.g. items/holdings on e-only shared records; e-holdings records),
+      # this implementation checks for the presence of items/holdings data
+      # in the processed argot.
       # Records with ONLY an order record will NOT be assigned an
       #  access_type value, given that it is presumed the item is on order
       #  and not at all accessible yet.
-      # @param rec [MARC::Record] the record to be checked.
-      # @param _ctx [Object] extra context or data to be used in the test
+      # @param _rec [MARC::Record] the record to be checked.
+      # @param ctx [Object] extra context or data to be used in the test
       #   (for overrides)
-      def physical_access?(rec, _ctx = {})
-        checkfields = []
-        rec.each_by_tag('999') { |f| checkfields << f if f.indicator1 == '9' && f.indicator2.to_i < 3}
-        if checkfields.size > 0
-          return true
-        else
-          return false
-        end
+      def physical_access?(_rec, ctx)
+        return true if (ctx.output_hash.fetch('items', []).any? ||
+                        ctx.output_hash.fetch('holdings', []).any?)
+
+        false
       end
 
       def filmfinder?(rec)

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.4.72'.freeze
+  VERSION = '0.4.73'.freeze
 end

--- a/spec/data/unc/UNCb3410672.xml
+++ b/spec/data/unc/UNCb3410672.xml
@@ -1,0 +1,161 @@
+<?xml version='1.0'?>
+<collection xmlns='http://www.loc.gov/MARC21/slim' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'>
+<record>
+  <leader>02313nas a2200469 a 4500</leader>
+  <controlfield tag='001'>10827510</controlfield>
+  <controlfield tag='003'>OCoLC</controlfield>
+  <controlfield tag='005'>20130912082000.0</controlfield>
+  <controlfield tag='008'>840611c19839999ncumr pbbs   f0    0eng c</controlfield>
+  <controlfield tag='007'>he bmb024bbca</controlfield>
+  <datafield tag='010' ind1=' ' ind2=' '>
+    <subfield code='a'>sn 87042587</subfield>
+  </datafield>
+  <datafield tag='035' ind1=' ' ind2=' '>
+    <subfield code='a'>(GPO)97104240</subfield>
+  </datafield>
+  <datafield tag='037' ind1=' ' ind2=' '>
+    <subfield code='b'>National Climatic Data Center, Federal Building, Asheville, N.C. 28801</subfield>
+  </datafield>
+  <datafield tag='040' ind1=' ' ind2=' '>
+    <subfield code='a'>GPO</subfield>
+    <subfield code='b'>eng</subfield>
+    <subfield code='c'>GPO</subfield>
+    <subfield code='d'>GPO</subfield>
+    <subfield code='d'>GPA</subfield>
+    <subfield code='d'>GPO</subfield>
+    <subfield code='d'>OCLCQ</subfield>
+    <subfield code='d'>GPO</subfield>
+    <subfield code='d'>MvI</subfield>
+  </datafield>
+  <datafield tag='042' ind1=' ' ind2=' '>
+    <subfield code='a'>pcc</subfield>
+  </datafield>
+  <datafield tag='043' ind1=' ' ind2=' '>
+    <subfield code='a'>n-us-az</subfield>
+  </datafield>
+  <datafield tag='074' ind1=' ' ind2=' '>
+    <subfield code='a'>0274-E-03 (online)</subfield>
+  </datafield>
+  <datafield tag='086' ind1='0' ind2=' '>
+    <subfield code='a'>C 55.287/4:</subfield>
+  </datafield>
+  <datafield tag='086' ind1='0' ind2=' '>
+    <subfield code='a'>C 55.286/6-3:</subfield>
+  </datafield>
+  <datafield tag='245' ind1='0' ind2='0'>
+    <subfield code='a'>Arizona monthly local climatological data</subfield>
+    <subfield code='h'>[microform].</subfield>
+  </datafield>
+  <datafield tag='260' ind1=' ' ind2=' '>
+    <subfield code='a'>[Asheville, N.C.] :</subfield>
+    <subfield code='b'>DOC, NOAA, NESDIS, NCDC</subfield>
+  </datafield>
+  <datafield tag='300' ind1=' ' ind2=' '>
+    <subfield code='a'>volumes ;</subfield>
+    <subfield code='c'>28 cm</subfield>
+  </datafield>
+  <datafield tag='310' ind1=' ' ind2=' '>
+    <subfield code='a'>Monthly</subfield>
+  </datafield>
+  <datafield tag='336' ind1=' ' ind2=' '>
+    <subfield code='a'>text</subfield>
+    <subfield code='b'>txt</subfield>
+    <subfield code='2'>rdacontent</subfield>
+  </datafield>
+  <datafield tag='337' ind1=' ' ind2=' '>
+    <subfield code='a'>microform</subfield>
+    <subfield code='b'>h</subfield>
+    <subfield code='2'>rdamedia</subfield>
+  </datafield>
+  <datafield tag='338' ind1=' ' ind2=' '>
+    <subfield code='a'>microfiche</subfield>
+    <subfield code='b'>he</subfield>
+    <subfield code='2'>rdacarrier</subfield>
+  </datafield>
+  <datafield tag='362' ind1='1' ind2=' '>
+    <subfield code='a'>Began with Oct. 1983.</subfield>
+  </datafield>
+  <datafield tag='500' ind1=' ' ind2=' '>
+    <subfield code='a'>Previously classed: C 55.287/4:</subfield>
+  </datafield>
+  <datafield tag='500' ind1=' ' ind2=' '>
+    <subfield code='a'>Microfiche ceased.</subfield>
+  </datafield>
+  <datafield tag='500' ind1=' ' ind2=' '>
+    <subfield code='a'>Direct requests for paper copy subscription to the publisher: U.S. Dept. of Commerce, National Climatic Data Center, Federal Bldg., Asheville, N.C. 28801-2696.</subfield>
+  </datafield>
+  <datafield tag='530' ind1=' ' ind2=' '>
+    <subfield code='a'>Available via Internet for individual cities.</subfield>
+  </datafield>
+  <datafield tag='533' ind1=' ' ind2=' '>
+    <subfield code='a'>Microfiche.</subfield>
+    <subfield code='m'>&lt;Nov. 1983&gt;-199</subfield>
+    <subfield code='b'>[Asheville, N.C. :</subfield>
+    <subfield code='c'>National Climatic Data Center].</subfield>
+    <subfield code='e'>microfiche : negative.</subfield>
+  </datafield>
+  <datafield tag='588' ind1='0' ind2=' '>
+    <subfield code='a'>Nov. 1983; title from header.</subfield>
+  </datafield>
+  <datafield tag='588' ind1='0' ind2=' '>
+    <subfield code='a'>Nov. 1983; title from header.</subfield>
+  </datafield>
+  <datafield tag='650' ind1=' ' ind2='0'>
+    <subfield code='a'>Meteorology</subfield>
+    <subfield code='0'>http://id.loc.gov/authorities/subjects/sh85084334</subfield>
+    <subfield code='z'>Arizona</subfield>
+    <subfield code='0'>http://id.loc.gov/authorities/names/n79034873</subfield>
+    <subfield code='v'>Statistics</subfield>
+    <subfield code='0'>http://id.loc.gov/authorities/subjects/sh99001414</subfield>
+    <subfield code='v'>Periodicals.</subfield>
+    <subfield code='0'>http://id.loc.gov/authorities/subjects/sh99001647</subfield>
+  </datafield>
+  <datafield tag='651' ind1=' ' ind2='0'>
+    <subfield code='a'>Arizona</subfield>
+    <subfield code='0'>http://id.loc.gov/authorities/names/n79034873</subfield>
+    <subfield code='x'>Climate</subfield>
+    <subfield code='0'>http://id.loc.gov/authorities/subjects/sh00007747</subfield>
+    <subfield code='v'>Statistics</subfield>
+    <subfield code='0'>http://id.loc.gov/authorities/subjects/sh99001414</subfield>
+    <subfield code='v'>Periodicals.</subfield>
+    <subfield code='0'>http://id.loc.gov/authorities/subjects/sh99001647</subfield>
+  </datafield>
+  <datafield tag='710' ind1='2' ind2=' '>
+    <subfield code='a'>National Climatic Data Center (U.S.)</subfield>
+    <subfield code='0'>http://id.loc.gov/authorities/names/n83004739</subfield>
+  </datafield>
+  <datafield tag='856' ind1='4' ind2='1'>
+    <subfield code='u'>https://purl.fdlp.gov/GPO/LPS1384</subfield>
+    <subfield code='3'>click on provided links to display issues available; then click on index of city codes to view particular issues</subfield>
+  </datafield>
+  <datafield tag='907' ind1=' ' ind2=' '>
+    <subfield code='a'>b3410672</subfield>
+  </datafield>
+  <datafield tag='999' ind1='9' ind2='2'>
+    <subfield code='a'>c3557136</subfield>
+    <subfield code='b'>erra</subfield>
+    <subfield code='c'>0</subfield>
+  </datafield>
+  <datafield tag='999' ind1='9' ind2='3'>
+    <subfield code='0'>c3557136</subfield>
+    <subfield code='2'>852</subfield>
+    <subfield code='3'>c</subfield>
+    <subfield code='b'>552210</subfield>
+    <subfield code='h'>C 55.287/4:</subfield>
+    <subfield code='z'>For holdings, ask at Davis Reference Desk.</subfield>
+  </datafield>
+  <datafield tag='999' ind1='9' ind2='3'>
+    <subfield code='0'>c3557136</subfield>
+    <subfield code='2'>852</subfield>
+    <subfield code='3'>e</subfield>
+    <subfield code='p'>HAZE-5035-00001</subfield>
+    <subfield code='t'>1</subfield>
+  </datafield>
+  <datafield tag='999' ind1='0' ind2='0'>
+    <subfield code='a'>2013-10-07 00:00:00-04</subfield>
+    <subfield code='c'>2004-10-05 07:58:02-04</subfield>
+    <subfield code='u'>2020-10-14 15:38:52-04</subfield>
+    <subfield code='m'>a</subfield>
+  </datafield>
+</record>
+</collection>

--- a/spec/data/unc/UNCb7655176.xml
+++ b/spec/data/unc/UNCb7655176.xml
@@ -1,0 +1,150 @@
+<?xml version='1.0'?>
+<collection xmlns='http://www.loc.gov/MARC21/slim' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'>
+<record>
+  <leader>02635cam a2200421 i 4500</leader>
+  <controlfield tag='001'>864304680</controlfield>
+  <controlfield tag='003'>OCoLC</controlfield>
+  <controlfield tag='005'>20140429084755.0</controlfield>
+  <controlfield tag='008'>131127s2013    dcua     b   f000 0 eng c</controlfield>
+  <datafield tag='019' ind1=' ' ind2=' '>
+    <subfield code='a'>tmp97417582</subfield>
+  </datafield>
+  <datafield tag='040' ind1=' ' ind2=' '>
+    <subfield code='a'>GPO</subfield>
+    <subfield code='b'>eng</subfield>
+    <subfield code='e'>rda</subfield>
+    <subfield code='c'>GPO</subfield>
+    <subfield code='d'>GPO</subfield>
+    <subfield code='d'>SEN</subfield>
+    <subfield code='d'>GPO</subfield>
+    <subfield code='d'>UOI</subfield>
+    <subfield code='d'>GPO</subfield>
+    <subfield code='d'>MvI</subfield>
+  </datafield>
+  <datafield tag='042' ind1=' ' ind2=' '>
+    <subfield code='a'>pcc</subfield>
+  </datafield>
+  <datafield tag='043' ind1=' ' ind2=' '>
+    <subfield code='a'>n-us---</subfield>
+  </datafield>
+  <datafield tag='050' ind1='1' ind2='4'>
+    <subfield code='a'>KF27</subfield>
+    <subfield code='b'>.P89624 2013b</subfield>
+  </datafield>
+  <datafield tag='074' ind1=' ' ind2=' '>
+    <subfield code='a'>1024-A-01</subfield>
+  </datafield>
+  <datafield tag='086' ind1='0' ind2=' '>
+    <subfield code='a'>Y 4.T 68/2:113-15</subfield>
+  </datafield>
+  <datafield tag='110' ind1='1' ind2=' '>
+    <subfield code='a'>United States.</subfield>
+    <subfield code='b'>Congress.</subfield>
+    <subfield code='b'>House.</subfield>
+    <subfield code='b'>Committee on Transportation and Infrastructure.</subfield>
+    <subfield code='b'>Subcommittee on Aviation,</subfield>
+    <subfield code='0'>http://id.loc.gov/authorities/names/no95026962</subfield>
+    <subfield code='e'>author.</subfield>
+  </datafield>
+  <datafield tag='245' ind1='1' ind2='0'>
+    <subfield code='a'>Review of the FAA&apos;s progress in implementing the FAA Modernization and Reform Act  :</subfield>
+    <subfield code='b'>hearing before the Subcommittee on Aviation of the Committee on Transportation and Infrastructure, House of Representatives, one Hundred Thirteenth Congress, First Session, May 16, 2013.</subfield>
+  </datafield>
+  <datafield tag='264' ind1=' ' ind2='1'>
+    <subfield code='a'>Washington :</subfield>
+    <subfield code='b'>U.S. Government Printing Office,</subfield>
+    <subfield code='c'>2013.</subfield>
+  </datafield>
+  <datafield tag='264' ind1=' ' ind2='2'>
+    <subfield code='a'>Washington, District of Columbia :</subfield>
+    <subfield code='b'>For sale by the Superintendent of Documents, U.S. Government Printing Office</subfield>
+  </datafield>
+  <datafield tag='300' ind1=' ' ind2=' '>
+    <subfield code='a'>viii, 140 pages :</subfield>
+    <subfield code='b'>illustrations ;</subfield>
+    <subfield code='c'>24 cm</subfield>
+  </datafield>
+  <datafield tag='336' ind1=' ' ind2=' '>
+    <subfield code='a'>text</subfield>
+    <subfield code='2'>rdacontent</subfield>
+  </datafield>
+  <datafield tag='337' ind1=' ' ind2=' '>
+    <subfield code='a'>unmediated</subfield>
+    <subfield code='2'>rdamedia</subfield>
+  </datafield>
+  <datafield tag='338' ind1=' ' ind2=' '>
+    <subfield code='a'>volume</subfield>
+    <subfield code='2'>rdacarrier</subfield>
+  </datafield>
+  <datafield tag='500' ind1=' ' ind2=' '>
+    <subfield code='a'>Shipping list no.: 2014-0058-P.</subfield>
+  </datafield>
+  <datafield tag='500' ind1=' ' ind2=' '>
+    <subfield code='a'>&quot;113-15.&quot;</subfield>
+  </datafield>
+  <datafield tag='504' ind1=' ' ind2=' '>
+    <subfield code='a'>Includes bibliographical references.</subfield>
+  </datafield>
+  <datafield tag='530' ind1=' ' ind2=' '>
+    <subfield code='a'>Also available via the Internet from the GPO Access web site. Address as of 01/16/14: http://purl.fdlp.gov/GPO/gpo41775  ; current access is available via PURL.</subfield>
+  </datafield>
+  <datafield tag='610' ind1='1' ind2='0'>
+    <subfield code='a'>United States.</subfield>
+    <subfield code='b'>Federal Aviation Administration.</subfield>
+    <subfield code='0'>http://id.loc.gov/authorities/names/n79034443</subfield>
+  </datafield>
+  <datafield tag='610' ind1='1' ind2='0'>
+    <subfield code='a'>United States.</subfield>
+    <subfield code='b'>Federal Aviation Administration</subfield>
+    <subfield code='0'>http://id.loc.gov/authorities/names/n79034443</subfield>
+    <subfield code='x'>Appropriations and expenditures.</subfield>
+    <subfield code='0'>http://id.loc.gov/authorities/subjects/sh2002007884</subfield>
+  </datafield>
+  <datafield tag='650' ind1=' ' ind2='0'>
+    <subfield code='a'>Aeronautics, Commercial</subfield>
+    <subfield code='x'>Law and legislation</subfield>
+    <subfield code='z'>United States.</subfield>
+    <subfield code='0'>http://id.loc.gov/authorities/subjects/sh2007100700</subfield>
+  </datafield>
+  <datafield tag='776' ind1='0' ind2='8'>
+    <subfield code='i'>Microfiche version:</subfield>
+    <subfield code='a'>United States. Congress. House. Committee on Transportation and Infrastructure. Subcommittee on Aviation.</subfield>
+    <subfield code='t'>Review of the FAA&apos;s progress in implementing the FAA Modernization and Reform Act</subfield>
+    <subfield code='w'>(OCoLC)878530581</subfield>
+  </datafield>
+  <datafield tag='776' ind1='0' ind2='8'>
+    <subfield code='i'>Online version:</subfield>
+    <subfield code='a'>United States. Congress. House. Committee on Transportation and Infrastructure. Subcommittee on Aviation.</subfield>
+    <subfield code='t'>Review of the FAA&apos;s progress in implementing the FAA Modernization and Reform Act</subfield>
+    <subfield code='w'>(OCoLC)864304539</subfield>
+  </datafield>
+  <datafield tag='856' ind1='4' ind2='1'>
+    <subfield code='3'>PDF version:</subfield>
+    <subfield code='u'>http://purl.fdlp.gov/GPO/gpo41775</subfield>
+  </datafield>
+  <datafield tag='919' ind1=' ' ind2=' '>
+    <subfield code='a'>dwsgpo</subfield>
+  </datafield>
+  <datafield tag='907' ind1=' ' ind2=' '>
+    <subfield code='a'>b7655176</subfield>
+  </datafield>
+  <datafield tag='999' ind1='9' ind2='1'>
+    <subfield code='i'>i10194042</subfield>
+    <subfield code='l'>dcpf</subfield>
+    <subfield code='s'>-</subfield>
+    <subfield code='t'>20</subfield>
+    <subfield code='c'>1</subfield>
+    <subfield code='o'>0</subfield>
+    <subfield code='h'>0</subfield>
+    <subfield code='b'>00047786813</subfield>
+    <subfield code='p'>0860#</subfield>
+    <subfield code='q'>|aY 4.T 68/2:113-15</subfield>
+  </datafield>
+  <datafield tag='999' ind1='0' ind2='0'>
+    <subfield code='a'>2014-06-05 00:00:00-04</subfield>
+    <subfield code='c'>2014-01-10 14:23:18-05</subfield>
+    <subfield code='u'>2020-05-05 16:44:23-04</subfield>
+    <subfield code='m'>a</subfield>
+  </datafield>
+</record>
+</collection>

--- a/spec/macros/shared/physical_media_spec.rb
+++ b/spec/macros/shared/physical_media_spec.rb
@@ -287,10 +287,12 @@ end
     result = resource_type_archival_unc.fetch('physical_media', [])
     expect(result).not_to include('Print')
   end
-  
+
   #Clear physical media labels when there are no physical holdings
   let(:unc_no_items) { run_traject_json('unc', 'UNCb2978655', 'xml')}
   let(:unc_with_items) { run_traject_json('unc', 'UNCb4243452', 'xml')}
+  let(:unc_shared_eonly) { run_traject_json('unc', 'UNCb7655176', 'xml')}
+  let(:unc_eonly_holdings) { run_traject_json('unc', 'UNCb3410672', 'xml')}
   let(:duke_no_items) { run_traject_json('duke', 'DUKE003894579', 'xml')}
   let(:duke_with_items) { run_traject_json('duke', 'DUKE003271109', 'xml')}
   let(:nccu_no_items) { run_traject_json('nccu', 'physical_media1', 'xml')}
@@ -298,6 +300,16 @@ end
 
   it '(MTA UNC) Does NOT set physical_media if there are no items' do
     result = unc_no_items.fetch('physical_media', [])
+    expect(result).to eq(['Online'])
+  end
+
+  it '(MTA UNC) Does NOT set physical_media for e-only shared records' do
+    result = unc_shared_eonly.fetch('physical_media', [])
+    expect(result).to eq(['Online'])
+  end
+
+  it '(MTA UNC) Does NOT set physical_media if only e-holdings records attached' do
+    result = unc_eonly_holdings.fetch('physical_media', [])
     expect(result).to eq(['Online'])
   end
 

--- a/spec/unc_local_note_spec.rb
+++ b/spec/unc_local_note_spec.rb
@@ -4,23 +4,26 @@ require 'spec_helper'
 describe MarcToArgot do
   include Util::TrajectRunTest
   let(:corpdonor1) { run_traject_json('unc', '791-1') }
-  
-  it '(UNC) sets a local note from 791 field with indicators 2b' do
+
+  it '(UNC) sets local notes' do
     rec = make_rec
     rec << MARC::DataField.new('590', ' ',  ' ', ['a', 'Test note.'])
+    rt = run_traject_on_record('unc', rec)['note_local']
+    expect(rt).to eq([{'value' => 'Test note.'}])
+  end
+
+  it '(UNC) sets indexed-only local notes from MARC donor fields (790/791)' do
+    rec = make_rec
     rec << MARC::DataField.new('791', '2',  ' ', ['a', 'William A. Whitaker Foundation Library Fund.'])
     rec << MARC::DataField.new('790', '0',  ' ', ['a', 'Scaglione, Aldo D.'])
     rt = run_traject_on_record('unc', rec)['note_local']
     expect(rt).to(
       eq([
            {
-             'value' => 'Test note.'
+             'indexed_value' => 'Purchased using funds from the William A. Whitaker Foundation Library Fund.'
            },
            {
-             'value' => 'Purchased using funds from the William A. Whitaker Foundation Library Fund.'
-           },
-           {
-             'value' => 'Donated by Scaglione, Aldo D.'
+             'indexed_value' => 'Donated by Scaglione, Aldo D.'
            }
          ])
     )


### PR DESCRIPTION
UNC only:
- `note_local` fields containing donor info are indexed-only
- clears physical_media values for online-only records in two UNC edge cases not handled by TD-1025 (shared eresource sets; local records with only an electronic holdings record attached)
- links to `panopto.com` are set as restricted