### PR TITLE
(Duke only) map PLGN to duke;dukelily;dukelilygrap

### DIFF
--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.4.75'.freeze
+  VERSION = '0.4.76'.freeze
 end

--- a/lib/translation_maps/duke/location_hierarchy.yaml
+++ b/lib/translation_maps/duke/location_hierarchy.yaml
@@ -28,6 +28,7 @@ LRES: duke;dukelaww;dukelawwrees|law;lawdukw;lawdukwrees
 LRESV: duke;dukelaww;dukelawwrees|law;lawdukw;lawdukwrees
 LSC: duke;dukelibr
 LILLY: duke;dukelily
+PLGN: duke;dukelily;dukelilygrap
 PLW: duke;dukelily;dukelilycure
 PLV8: duke;dukelily;dukelilydeds
 PLR: duke;dukelily;dukelilyrece


### PR DESCRIPTION
Duke's Lilly Library has added a new collection code for their graphic novel collection. This change maps the new code to a location in the location facet hierarchy.