### PR TITLE
TD-1076: Fix crash in .short_title when MARC field is whitespace-only

### DIFF
--- a/lib/marc_to_argot/macros/shared/title.rb
+++ b/lib/marc_to_argot/macros/shared/title.rb
@@ -36,6 +36,8 @@ module MarcToArgot
               return if value.empty?
 
               words = value.split(/\s+/)
+              return if words.empty?
+
               if words.length <= max_length
                 # strip any punctuation off the last word
                 words[-1] = words[-1].gsub(/[^a-z0-9]$/i, '')

--- a/lib/marc_to_argot/version.rb
+++ b/lib/marc_to_argot/version.rb
@@ -1,3 +1,3 @@
 module MarcToArgot
-  VERSION = '0.4.79'.freeze
+  VERSION = '0.4.80'.freeze
 end

--- a/spec/macros/shared/title_spec.rb
+++ b/spec/macros/shared/title_spec.rb
@@ -23,6 +23,13 @@ describe MarcToArgot::Macros::Shared::Title do
       result = run_traject_on_record('ncsu', rec)
       expect(result['short_title']).to be_nil
     end
+
+    it 'does not error out when MARC field is whitespace-only' do
+      rec = make_rec
+      rec << MARC::DataField.new('245', '0', '0', ['a', ' '])
+      result = run_traject_on_record('ncsu', rec)
+      expect(result['short_title']).to be_nil
+    end
   end
 
   context 'short title in 245 and linked 880 present' do


### PR DESCRIPTION
Fix crash when setting short_title via shared macro (when encountering a MARC 245$a that is whitespace-only)