### PR TITLE
Duke alma integration

### DIFF
--- a/lib/data/duke/marc_specs.yml
+++ b/lib/data/duke/marc_specs.yml
@@ -1,7 +1,5 @@
 date_cataloged:
   - 946b
-  - 943n
-  - 914d
 subject_headings_local:
   - 690ax
   - 691abvxyz

--- a/lib/marc_to_argot/macros/duke/items.rb
+++ b/lib/marc_to_argot/macros/duke/items.rb
@@ -188,11 +188,16 @@ module MarcToArgot
               # multiple values (known issue for Duke's local availability transformation)
               availabilities = collect_subfield_values_by_code(field, 'x')
               if availabilities.length() > 1
-                holding['status'] = availabilities.include?('Available') ? 'Available' : 'Check holdings'
+                holding['status'] = 'Check holdings'
+                holding['status'] = 'Available' if availabilities.include?('Available')
+                holding['status'] = 'Unavailable' if availabilities.all? { |a| a.eql?('Unavailable') }
               else
                 # The availablities list has either 1 or no elements (empty).
                 # No elements? Default to "Check Holdings"
                 # 1 element? Use that one.
+                #
+                # And remember, for Duke, it's "Live Circulation Status Update" facility will
+                # provide a real-time answer.
                 holding['status'] = availabilities.empty? ? 'Check holdings' : availabilities[0]
               end
 

--- a/spec/macros/duke/items_spec.rb
+++ b/spec/macros/duke/items_spec.rb
@@ -54,6 +54,19 @@ describe MarcToArgot::Macros::Duke::Items do
       )
     end
 
+    it 'correctly sets holding "status" to "Unavailable" when multiple "x" subfields all contain "Unavailable"' do
+      rec = make_rec
+      rec << MARC::DataField.new('852', '0', ' ',
+                                ['b', 'PERKN'],
+                                ['x', 'Unavailable'],
+                                ['x', 'Unavailable']
+                                )
+      result = run_traject_on_record('duke', rec)
+      expect(JSON.parse(result['holdings'][0])['status']).to(
+        eq("Unavailable")
+      )
+    end
+
     it 'correctly sets holding status to "Check holdings" when multiple "x" subfields exists and one has "Check holdings"' do
       rec = make_rec
       rec << MARC::DataField.new('852', '0', ' ',


### PR DESCRIPTION
Addresses rare (but possible) case of a Duke record having multiple 852x subfields each containing "Unavailable". Includes additional test spec for verification.

Restores Duke's `date_cataloged` marc_spec to map to 946b, until Duke's metadata team reaches an implementation consensus.