### PR TITLE
Adds 'duke.userservices.exlibrisgroup.com' to unproxied_resticted list

### DIFF
--- a/lib/data/duke/unproxied_restricted.yml
+++ b/lib/data/duke/unproxied_restricted.yml
@@ -16,3 +16,4 @@ domains_and_urls:
   - zephyr.bvdinfo.com
   - getitatduke.library.duke.edu
   - apps.intelligize.com
+  - duke.userservices.exlibrisgroup.com

--- a/lib/marc_to_argot/macros/duke/urls.rb
+++ b/lib/marc_to_argot/macros/duke/urls.rb
@@ -35,7 +35,7 @@ module MarcToArgot
               url[:href] = "#{soa_url_conf['soa_url']}#{portfolio_id}" if journal_resource_types.include?(resource_type)
 
               url[:note] = resource_note unless resource_note.empty?
-              url[:restricted] = 'false' unless url_restricted?(raw_href, 'fulltext')
+              url[:restricted] = 'false' unless url_restricted?(url[:href], 'fulltext')
               acc << url.to_json
             end
 

--- a/spec/macros/duke/urls_spec.rb
+++ b/spec/macros/duke/urls_spec.rb
@@ -45,11 +45,11 @@ describe MarcToArgot::Macros::Duke::Urls do
       )
     end
 
-    context 'DUKE-AK-285-add-url' do
+    # For this spec, we're using a record that represents a 943 field from Alma
+    # that has a 'raw href' from the 943d, and is expected to be changed.
+    context 'DUKE-AK-285-add-duke-userservices' do
       it 'does not set \'restricted: false\' when the URL includes \'duke.userservices.exlibrisgroup.com\'' do
-        expect(JSON.parse(url_943_journal_case['url'][0])['restricted']).to(
-          eq('false')
-        )
+        expect(JSON.parse(url_943_journal_case['url'][0])['restricted']).to be_nil
       end
     end
 

--- a/spec/macros/duke/urls_spec.rb
+++ b/spec/macros/duke/urls_spec.rb
@@ -19,7 +19,6 @@ describe MarcToArgot::Macros::Duke::Urls do
   }
 
   context 'Duke' do
-
     it 'restricted is not set to false for fulltext URLs with the proxy prefix' do
       expect(JSON.parse(restricted['url'][0])['restricted']).to be_nil
     end
@@ -46,8 +45,16 @@ describe MarcToArgot::Macros::Duke::Urls do
       )
     end
 
+    context 'DUKE-AK-285-add-url' do
+      it 'does not set \'restricted: false\' when the URL includes \'duke.userservices.exlibrisgroup.com\'' do
+        expect(JSON.parse(url_943_journal_case['url'][0])['restricted']).to(
+          eq('false')
+        )
+      end
+    end
+
     context 'DUKE-BMCK-13-intelligize' do
-      it 'does not set restricted=false when the URL includes apps.intelligize.com' do
+      it 'does not set \'restricted: false\' when the URL includes \'apps.intelligize.com\'' do
         rec = make_rec
         rec << MARC::DataField.new('856', '4', '0',
                                   ['y', 'Law School users click here to access Intelligize'],


### PR DESCRIPTION
Includes new test spec, specifically for duke.userservices.exlibrisgroup.com. 
  
**The relevant processing only applies to records with online items from:**
- `943` fields, where `943q` is one of "JOURNAL" or "NEWSPAPER" -- (_implemented as requested by Jacquie Samples in "Alma - Phase 1"_). 
  
The code in `urls.rb` will assign the value of `soa_url_conf['soa_url'] when the 943-derived field is JOURNAL or NEWSPAPER (again, Jacquie Samples in "Alma - Phase 1"). 
  
The `soa_url_conf['soa_url']` will contain the pattern, `duke.userservices.exlibrisgroup.com`.  
(see `lib/data/duke/soa_url_conf.yml`). 